### PR TITLE
(Discuss, don't merge) Made -p add the path to the package.path as well.

### DIFF
--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -1,6 +1,7 @@
 /* See Copyright Notice in ../LICENSE.txt */
 
 #include <stdio.h>
+#include <unistd.h>
 
 #include "tllvmutil.h"
 #include "llvm/Target/TargetLibraryInfo.h"


### PR DESCRIPTION
The problem I've found with -p is it only modifies terralib.path, which means if the terra files require lua files it will fail. So this PR looks for ?.t in the new terra path, replaces it with ?.lua and prepends it to the package.path.

The drawback of this code is that it only replaces the first ?.t with ?.lua. A more complete fix would be to replace all instances of .t with .lua in the path (or more flexible, but more annoying, allow specifying a lua path as well in a separate argument.)
