### PR TITLE
Add routines to clean up terra state

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,6 +71,8 @@ int main(int argc, char ** argv) {
     }
     
     printstats(L);
+    terra_free (L);
+    terra_llvmshutdown ();
 
     return 0;
 }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -182,9 +182,8 @@ int terra_compilerinit(struct terra_State * T) {
     
     lua_pop(T->L,1); //remove terra from stack
     
-    T->C = (terra_CompilerState*) malloc(sizeof(terra_CompilerState));
-    memset(T->C, 0, sizeof(terra_CompilerState));
-    
+    T->C = new terra_CompilerState;
+    T->C->next_unused_id = 0;
     T->C->ctx = new LLVMContext();
     T->C->m = new Module("terra",*T->C->ctx);
     
@@ -223,6 +222,18 @@ int terra_compilerinit(struct terra_State * T) {
     T->C->jiteventlistener = new DisassembleFunctionListener(T);
     T->C->ee->RegisterJITEventListener(T->C->jiteventlistener);
     
+    return 0;
+}
+
+int terra_compilerfree(struct terra_State * T) {
+    T->C->ee->UnregisterJITEventListener(T->C->jiteventlistener);
+    delete T->C->jiteventlistener;
+    delete T->C->mi;
+    delete T->C->fpm;
+    delete T->C->ee;
+    delete T->C->tm;
+    delete T->C->ctx;
+    delete T->C;
     return 0;
 }
 

--- a/src/tcompiler.h
+++ b/src/tcompiler.h
@@ -3,5 +3,6 @@
 
 struct terra_State;
 int terra_compilerinit(struct terra_State * T);
+int terra_compilerfree(struct terra_State * T);
 
 #endif

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -169,5 +169,8 @@ int terra_cudainit(struct terra_State * T) {
 int terra_cudainit(struct terra_State * T) {
     return 0;
 }
+int terra_cudafree(struct terra_State * T) {
+    return 0;
+}
 #endif
 

--- a/src/tcuda.h
+++ b/src/tcuda.h
@@ -3,5 +3,6 @@
 
 struct terra_State;
 int terra_cudainit(struct terra_State * T);
+int terra_cudafree(struct terra_State * T);
 
 #endif

--- a/src/terra.cpp
+++ b/src/terra.cpp
@@ -185,6 +185,16 @@ int terra_init(lua_State * L) {
     return 0;   
 }
 
+int terra_free(lua_State * L) {
+    terra_State * T = getterra (L);
+    lua_close (L);
+    terra_cudafree (T);
+    terra_compilerfree (T);
+    free (T);
+
+    return 0;   
+}
+
 struct FileInfo {
     FILE * file;
     char buf[512];

--- a/src/terra.h
+++ b/src/terra.h
@@ -13,11 +13,13 @@ extern "C" {
 #include "lauxlib.h"
 
 int terra_init(lua_State * L);
+int terra_free(lua_State * L);
 int terra_load(lua_State *L,lua_Reader reader, void *data, const char *chunkname);
 int terra_loadfile(lua_State * L, const char * file);
 int terra_loadbuffer(lua_State * L, const char *buf, size_t size, const char *name);
 int terra_loadstring(lua_State *L, const char *s);
 int terra_setverbose(lua_State * L, int v);
+void terra_llvmshutdown ();
 
 #define terra_dofile(L, fn) \
     (terra_loadfile(L, fn) || lua_pcall(L, 0, LUA_MULTRET, 0))

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -13,6 +13,7 @@
 #include "llvm/MC/MCRegisterInfo.h"
 #include "llvm/MC/MCSubtargetInfo.h"
 #include "llvm/Support/MemoryObject.h"
+#include "llvm/Support/ManagedStatic.h"
 
 using namespace llvm;
 
@@ -241,3 +242,6 @@ Module * llvmutil_extractmodule(Module * OrigMod, TargetMachine * TM, std::vecto
     
         return M;
 }
+
+extern "C" void terra_llvmshutdown () { llvm_shutdown (); }
+


### PR DESCRIPTION
The Terra API exposes no way to clean up the resources created by terra_init; I propose a replacement for lua_close to clean up all resources created by the terra instance. Additionally, the compiler state is allocated with new instead, since the structure contains a C++ object.
