### PR TITLE
Added support for llvm/clang version 3.3.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,7 +58,7 @@ FLAGS += -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_
 
 
 LLVM_VERSION_NUM=$(shell $(LLVM_CONFIG) --version | sed -e s/svn//)
-LLVM_VERSION=LLVM_$(shell echo $(LLVM_VERSION_NUM) | sed -e s/\\./_/)
+LLVM_VERSION=LLVM_$(shell echo $(LLVM_VERSION_NUM) | sed -e s/\\./_/g)
 
 FLAGS += -D$(LLVM_VERSION)
 

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -52,6 +52,8 @@
 #include "llvmheaders_32.h"
 #elif LLVM_3_3
 #include "llvmheaders_33.h"
+#elif LLVM_3_3_1
+#include "llvmheaders_33.h"
 #else
 #error "unsupported LLVM version"
 #include "llvmheaders_33.h" //for OSX code completion

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -405,7 +405,7 @@ public:
     bool HandleLiveness(FunctionDecl * f, const std::string & FuncName) {
         std::string prefix = "__makeeverythinginclanglive_";
         if(FuncName.substr(0,prefix.size()) == prefix) {
-            #if defined(LLVM_3_3)
+            #if defined(LLVM_3_3) || defined(LLVM_3_3_1)
             CompoundStmt * stmts = new (*Context) CompoundStmt(*Context, outputstmts, SourceLocation(), SourceLocation());
             #elif defined(LLVM_3_2) || defined(LLVM_3_1)
             CompoundStmt * stmts = new (*Context) CompoundStmt(*Context, &outputstmts[0], outputstmts.size(), SourceLocation(), SourceLocation());

--- a/src/tinline.cpp
+++ b/src/tinline.cpp
@@ -650,7 +650,7 @@ public:
 // doInitialization - Initializes the vector of functions that have been
 // annotated with the noinline attribute.
 bool SimpleManualInliner::doInitialization() {
-#ifdef LLVM_3_3
+#if defined(LLVM_3_3) || defined(LLVM_3_3_1)
     PassManagerWrapper W;
     W.PM = &PM;
     W.add(new DataLayout(*TM->getDataLayout()));


### PR DESCRIPTION
The official svn source for llvm and clang is actually version 3.3.1
when compiling against the release_33 branch. This commit adds support
for this point release when building terra.

The make file only converted the first period to an underscore. This has
been fixed so the llvm version is now reported as LLVM_3_3_1. The
appropriate preprocessor macros have been modified to allow this version
to follow the same path as LLVM_3_3.

All tests pass but I'm not sure if there are any sutble differences
between 3.3 and 3.3.1 that would make a difference to terra.
