### PR TITLE
Fixed compilation bug on Macs when unistd.h is not included

### DIFF
--- a/src/tdebug.cpp
+++ b/src/tdebug.cpp
@@ -8,7 +8,7 @@
 #include "tllvmutil.h"
 #include "terrastate.h"
 #include "tcompilerstate.h"
-#ifdef __linux__
+#if defined(__linux__) || defined(__APPLE__)
 #include <unistd.h>
 #endif
 


### PR DESCRIPTION
After attempting to compile Terra on my machine (Mid 2012 MBP), I received the following errors:

```
/usr/local/bin/../bin/clang++ -g -I build/LuaJIT-2.0.2/src -I /usr/local/Cellar/llvm/3.3/include -I /usr/local/bin/../include -I build -fPIC -D_GNU_SOURCE -D__STDC_CONSTANT_MACROS -D__STDC_FORMAT_MACROS -D__STDC_LIMIT_MACROS -O0 -fno-rtti -fno-common -Woverloaded-virtual -Wcast-qual -fvisibility-inlines-hidden -DLLVM_3_4 -DTERRA_CLANG_RESOURCE_DIRECTORY="\"/usr/local/bin/../lib/clang/3.4/include\"" src/tdebug.cpp -c -o build/tdebug.o
src/tdebug.cpp:63:5: error: use of undeclared identifier 'pipe'
    pipe(fds);
    ^
src/tdebug.cpp:66:28: error: use of undeclared identifier 'write'
    for(i = 1; i < maxN && write(fds[1],frame,sizeof(Frame)) != -1 && frame->addr && frame->next; i++) {
                           ^
src/tdebug.cpp:70:5: error: use of undeclared identifier 'close'
    close(fds[0]);
    ^
src/tdebug.cpp:71:5: error: use of undeclared identifier 'close'
    close(fds[1]);
    ^
4 errors generated.
make: *** [build/tdebug.o] Error 1
```

The problem is that `tdebug.cpp` uses functions from `unistd.h`, however the compiler directives indicates that only Linux systems should include `unistd.h`, so I modified the flag to note that either Macs or Linux systems should include `unistd.h`.

Upon further inspection, I realized that the PR below me had the same issues and I guess they just weren't pushed yet. Welp. I will note that I did not have the same difficulties that @sunetos had (perhaps because I was willing to use the older version of clang), but even following the README instructions to a tee didn't work for compiling on OS X, so it would be lovely if at least this small change could make it to the repo.
