### PR TITLE
Debian multiarch compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-build/
+*.o
+*.a
+*.so
+terra

--- a/build/.gitignore
+++ b/build/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2694,6 +2694,11 @@ static bool SaveAndLink(TerraCompilationUnit * CU, Module * M, std::vector<const
         cmd.insert(cmd.end(),linkargs->begin(),linkargs->end());
     
 #ifndef _WIN32
+#if defined(__amd64__)
+	cmd.push_back("-m64");
+#elif defined(__i386__)
+	#error "Only AMD64 target currently supported on x86"
+#endif
     cmd.push_back("-o");
     cmd.push_back(filename);
 #else

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,13 @@
+add.bc
+afile.txt
+benchmark_fannkuchredux
+benchmark_nbody
+dynlib
+hello
+hello.c
+output
+output.ll
+output2
+output2.bc
+renamed
+speed


### PR DESCRIPTION
Two commits here, the first is the multiarch updates you requested.
Unfortunately I ran into a bit of a problem, it seems that the clang-dev and llvm-dev packages aren't actually multarch aware yet (for "jessie").  Nevertheless, as all except the final link works correctly I expect it will happen quickly after the packager decides that it needs doing "now". 

The result is that it _should_ compile using "make TARGET_ARCH=-m64" as soon as the libraries become available, but right now the only completely tested part of these changes is actually running the 64bit executable on a, mostly, 32bit system. (which now works correctly for all your tests)

The second commit is a minor tidy-up of the .gitignore files.
