### PR TITLE
Add Docker build and test in Travis for Ubuntu 16.04, 18.04, 19.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ env:
   - HOMEBREW_NO_AUTO_UPDATE=1 # workaround for #421
   matrix:
   - CHECK_CLANG_FORMAT=1
+  - DOCKER_BUILD=ubuntu-16.04
+  - DOCKER_BUILD=ubuntu-18.04
+  - DOCKER_BUILD=ubuntu-19.10
   - LLVM_CONFIG=llvm-config-3.5 CLANG=clang-3.5
   - LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8
   - LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8 USE_CMAKE=1
@@ -39,11 +42,26 @@ matrix:
     - os: linux
       compiler: clang
       env: CHECK_CLANG_FORMAT=1
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=ubuntu-16.04
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=ubuntu-18.04
+    - os: linux
+      compiler: clang
+      env: DOCKER_BUILD=ubuntu-19.10
     # Various macOS tests seem to be broken.
     - os: osx
       compiler: gcc
     - os: osx
       env: CHECK_CLANG_FORMAT=1
+    - os: osx
+      env: DOCKER_BUILD=ubuntu-16.04
+    - os: osx
+      env: DOCKER_BUILD=ubuntu-18.04
+    - os: osx
+      env: DOCKER_BUILD=ubuntu-19.10
     - os: osx
       env: LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8
     - os: osx

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -15,4 +15,4 @@ RUN apt-get update -qq && \
 
 FROM ubuntu:$release
 
-COPY --from=0 /terra_install/* /usr/local
+COPY --from=0 /terra_install/* /usr/local/

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -9,18 +9,10 @@ COPY . /terra
 RUN apt-get update -qq && \
     apt-get install -qq build-essential cmake git llvm-6.0-dev libclang-6.0-dev clang-6.0 libedit-dev libncurses5-dev zlib1g-dev && \
     cd /terra/build && \
-    cmake .. && \
+    cmake -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
     make install -j4 && \
     make test
 
 FROM ubuntu:$release
 
-RUN mkdir /usr/local/include/terra
-COPY --from=0 /usr/local/include/terra/lua.h     /usr/local/include/terra
-COPY --from=0 /usr/local/include/terra/lualib.h  /usr/local/include/terra
-COPY --from=0 /usr/local/include/terra/lauxlib.h /usr/local/include/terra
-COPY --from=0 /usr/local/include/terra/luaconf.h /usr/local/include/terra
-COPY --from=0 /usr/local/lib/libterra_s.a        /usr/local/lib
-COPY --from=0 /usr/local/lib/terra.so            /usr/local/lib
-COPY --from=0 /usr/local/bin/terra               /usr/local/bin
-COPY --from=0 /usr/local/include/terra/terra.h   /usr/local/include/terra
+COPY --from=0 /terra_install/* /usr/local

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,0 +1,26 @@
+ARG release=16.04
+
+FROM ubuntu:$release
+
+ENV DEBIAN_FRONTEND noninteractive
+
+COPY . /terra
+
+RUN apt-get update -qq && \
+    apt-get install -qq build-essential cmake git llvm-6.0-dev libclang-6.0-dev clang-6.0 libedit-dev libncurses5-dev zlib1g-dev && \
+    cd /terra/build && \
+    cmake .. && \
+    make install -j4 && \
+    make test
+
+FROM ubuntu:$release
+
+RUN mkdir /usr/local/include/terra
+COPY --from=0 /usr/local/include/terra/lua.h     /usr/local/include/terra
+COPY --from=0 /usr/local/include/terra/lualib.h  /usr/local/include/terra
+COPY --from=0 /usr/local/include/terra/lauxlib.h /usr/local/include/terra
+COPY --from=0 /usr/local/include/terra/luaconf.h /usr/local/include/terra
+COPY --from=0 /usr/local/lib/libterra_s.a        /usr/local/lib
+COPY --from=0 /usr/local/lib/terra.so            /usr/local/lib
+COPY --from=0 /usr/local/bin/terra               /usr/local/bin
+COPY --from=0 /usr/local/include/terra/terra.h   /usr/local/include/terra

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+IFS=- read distro release <<< "$1"
+
+docker build --build-arg release=$release -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro .

--- a/travis.sh
+++ b/travis.sh
@@ -22,6 +22,11 @@ if [[ $CHECK_CLANG_FORMAT -eq 1 ]]; then
     exit 0
 fi
 
+if [[ -n $DOCKER_BUILD ]]; then
+    ./docker/build.sh $DOCKER_BUILD
+    exit 0
+fi
+
 if [[ $(uname) = Linux ]]; then
   sudo apt-get update -qq
   if [[ $LLVM_CONFIG = llvm-config-9 ]]; then


### PR DESCRIPTION
Hopefully this will help us sanity check that our install procedures are working and that there are no dependencies being hidden by Travis's magic. It might also help as a starting point if we ever needed to move to another CI...