### PR TITLE
Prune the set of Travis configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,19 +18,15 @@ env:
   - LLVM_CONFIG=llvm-config-3.5 CLANG=clang-3.5
   - LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8
   - LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8 USE_CMAKE=1
-  - LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0
   - LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0 USE_CMAKE=1
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0 USE_CUDA=1
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0 USE_CMAKE=1
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
   - LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0 USE_CMAKE=1 SLIB_INCLUDE_LLVM=0 SLIB_INCLUDE_LUAJIT=0
-  - LLVM_CONFIG=llvm-config-7 CLANG=clang-7 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
-  - LLVM_CONFIG=llvm-config-7 CLANG=clang-7 USE_CMAKE=1 SLIB_INCLUDE_LLVM=0 SLIB_INCLUDE_LUAJIT=0 USE_CUDA=1
+  - LLVM_CONFIG=llvm-config-7 CLANG=clang-7 USE_CMAKE=1
   - LLVM_CONFIG=llvm-config-8 CLANG=clang-8
   - LLVM_CONFIG=llvm-config-8 CLANG=clang-8 USE_CMAKE=1
-  - LLVM_CONFIG=llvm-config-8 CLANG=clang-8 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
-  - LLVM_CONFIG=llvm-config-8 CLANG=clang-8 USE_CMAKE=1 SLIB_INCLUDE_LLVM=0 SLIB_INCLUDE_LUAJIT=0 USE_CUDA=1
   - LLVM_CONFIG=llvm-config-9 CLANG=clang-9
   - LLVM_CONFIG=llvm-config-9 CLANG=clang-9 USE_CMAKE=1
   - LLVM_CONFIG=llvm-config-9 CLANG=clang-9 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
@@ -65,17 +61,11 @@ matrix:
     - os: osx
       env: LLVM_CONFIG=llvm-config-3.8 CLANG=clang-3.8
     - os: osx
-      env: LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0
-    - os: osx
       env: LLVM_CONFIG=llvm-config-5.0 CLANG=clang-5.0 USE_CMAKE=1
     - os: osx
       env: LLVM_CONFIG=llvm-config-6.0 CLANG=clang-6.0 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
     - os: osx
-      env: LLVM_CONFIG=llvm-config-7 CLANG=clang-7 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
-    - os: osx
       env: LLVM_CONFIG=llvm-config-8 CLANG=clang-8
-    - os: osx
-      env: LLVM_CONFIG=llvm-config-8 CLANG=clang-8 USE_CMAKE=1 STATIC_LLVM=0 STATIC_LUAJIT=0
     - os: osx
       env: LLVM_CONFIG=llvm-config-9 CLANG=clang-9
     - os: osx


### PR DESCRIPTION
Otherwise these tests just take too long to run, especially with the growth of LLVM versions Terra supports.