### PR TITLE
Allow vararg function definitions

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -1103,7 +1103,7 @@ function terra.defineobjects(fmt,envfn,...)
                 if not terra.isfunction(v) or v:isdefined() then
                     local typ = terra.types.placeholderfunction
                     if c.tree.returntype then
-                        typ = terra.types.functype(c.tree.parameters:map("type"),c.tree.returntype,false)
+                        typ = terra.types.functype(c.tree.parameters:map("type"),c.tree.returntype,c.tree.is_varargs)
                     end
                     v = T.terrafunction(nil,c.name,typ,c.tree)
                 end

--- a/tests/vararg.t
+++ b/tests/vararg.t
@@ -1,0 +1,48 @@
+C = terralib.includecstring [[
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+int checkargs(const char* f, va_list vl)
+{
+  if(strcmp(f, "%i%i%f%s"))
+    return 1;
+    
+  if(va_arg(vl, int) != -10)
+    return 2;
+  if(va_arg(vl, unsigned long long) != 60000000000001ULL)
+    return 3;
+  if(va_arg(vl, double) != 60.01)
+    return 4;
+  if(strcmp(va_arg(vl, const char*), "TesT"))
+    return 5;
+  return 0;
+}
+
+]]
+
+-- Test passthrough of varargs to another function
+
+local va_start = terralib.intrinsic("llvm.va_start", {&int8} -> {})
+local va_end = terralib.intrinsic("llvm.va_end", {&int8} -> {})
+
+terra Log(prefix : rawstring, f : rawstring, ...) : int
+  if C.strcmp(prefix, "preFIX") ~= 0 then
+    return 8
+  end
+  
+  var vl : C.va_list
+  va_start([&int8](&vl))
+  var i = C.checkargs(f, vl)
+  if i ~= 0 then
+    return i
+  end
+  va_end([&int8](&vl))
+  return 0
+end
+
+terra invoke() : int
+  Log("preFIX", "%i%i%f%s", -10, 60000000000001ULL, 60.01, "TesT")
+end
+
+assert(invoke() == 0)


### PR DESCRIPTION
It turns out that Terra can actually forward varargs if you allow vararg function definitions, by using LLVM's built-in `va_list` intrinsics. Here is an example of a logging function:

```
local va_start = terralib.intrinsic("llvm.va_start", {&int8} -> {})
local va_end = terralib.intrinsic("llvm.va_end", {&int8} -> {})

terra Log(level : int, f : rawstring, ...) : {}
  if level >= 0 then
    C.printf(Levels[level])
  end
  var vl : C.va_list
  va_start([&int8](&vl))
  C.vprintf(f, vl)
  va_end([&int8](&vl))
  C.printf("\n");
end
```

It may be possible to extract individual arguments out, but I haven't attempted to use LLVM's `va_arg` intrinsic, and Terra might not like it. This change simply forwards the varargs state to the function definition.