### PR TITLE
Mark LLVM versions 3.5-3.7 as deprecated

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,7 +24,7 @@ The following changes are included in this release:
 
 ## Deprecated features
 
-  * Deprecated support for all LLVM versions 3.4 and prior
+  * Deprecated support for all LLVM versions 3.7 and prior
   * Deprecated support for Make (Linux, macOS) and NMake (Windows) build systems
 
 ## Changed behaviors

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -135,9 +135,9 @@ The current recommended version of LLVM is **6.0**. The following versions are a
 
 | Version | CI Coverage | CUDA | Notes |
 | ------- | ----------- | ---- | ----- |
-| 3.5 | :heavy_check_mark: | :heavy_check_mark: | supports debug info |
-| 3.6 | | | |
-| 3.7 | | | |
+| 3.5 | :heavy_check_mark: | :heavy_check_mark: | **deprecated** |
+| 3.6 | | | **deprecated** |
+| 3.7 | | | **deprecated** |
 | 3.8 | :heavy_check_mark: | :heavy_check_mark: | |
 | 3.9 | | | |
 | 5.0 | :heavy_check_mark: | :heavy_check_mark: | |


### PR DESCRIPTION
This formally marks LLVM versions 3.5-3.7 deprecated, as per https://github.com/terralang/terra/issues/456.

No code changes yet, but anticipate that code support will be removed in approximately 6 months.