### PR TITLE
Additional fixes for LLVM 11.x (11.1) support 

### DIFF
--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -248,7 +248,7 @@ void moduleToPTX(terra_State *T, llvm::Module *M, int major, int minor, std::str
     // 	printf("[CUDA] Result size: %s\n", outs.str().c_str());
     // }
 
-    (*buf) = dest.str();
+    (*buf) = dest.str().str();
 #endif
 }
 
@@ -299,18 +299,18 @@ int terra_toptx(lua_State *L) {
     for (llvm::Module::iterator it = M->begin(), end = M->end(); it != end; ++it) {
         const char *prefix = "cudart:";
         size_t prefixsize = strlen(prefix);
-        std::string name = it->getName();
+        std::string name = it->getName().str();
         if (name.size() >= prefixsize && name.substr(0, prefixsize) == prefix) {
             std::string shortname = name.substr(prefixsize);
             it->setName(shortname);
         }
         if (!it->isDeclaration()) {
-            it->setName(sanitizeName(it->getName()));
+          it->setName(sanitizeName(it->getName().str()));
         }
     }
     for (llvm::Module::global_iterator it = M->global_begin(), end = M->global_end();
          it != end; ++it) {
-        it->setName(sanitizeName(it->getName()));
+      it->setName(sanitizeName(it->getName().str()));
     }
 
     std::string ptx;

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -301,16 +301,16 @@ int terra_toptx(lua_State *L) {
         size_t prefixsize = strlen(prefix);
         std::string name = it->getName().str();
         if (name.size() >= prefixsize && name.substr(0, prefixsize) == prefix) {
-          std::string shortname = name.substr(prefixsize);
-          it->setName(shortname);
+            std::string shortname = name.substr(prefixsize);
+            it->setName(shortname);
         }
         if (!it->isDeclaration()) {
-          it->setName(sanitizeName(it->getName().str()));
+            it->setName(sanitizeName(it->getName().str()));
         }
     }
     for (llvm::Module::global_iterator it = M->global_begin(), end = M->global_end();
          it != end; ++it) {
-      it->setName(sanitizeName(it->getName().str()));
+        it->setName(sanitizeName(it->getName().str()));
     }
 
     std::string ptx;

--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -301,8 +301,8 @@ int terra_toptx(lua_State *L) {
         size_t prefixsize = strlen(prefix);
         std::string name = it->getName().str();
         if (name.size() >= prefixsize && name.substr(0, prefixsize) == prefix) {
-            std::string shortname = name.substr(prefixsize);
-            it->setName(shortname);
+          std::string shortname = name.substr(prefixsize);
+          it->setName(shortname);
         }
         if (!it->isDeclaration()) {
           it->setName(sanitizeName(it->getName().str()));


### PR DESCRIPTION
Looks like you now need to use explicit LLVM string to std::string conversions.  I tested this with both LLVM 10.x and 11.x and all tests passed.  Did not check older versions of LLVM.

Building terra w/ GCC 10.2 failed due to the patches lines.  
