### PR TITLE
Remove -m flag because MCJIT is now mandatory

### DIFF
--- a/release/include/terra/terra.h
+++ b/release/include/terra/terra.h
@@ -16,7 +16,6 @@ int terra_init(lua_State *L);
 typedef struct { /* default values are 0 */
     int verbose; /*-v, print more debugging info (can be 1 for some, 2 for more) */
     int debug;   /*-g, turn on debugging symbols and base pointers */
-    int usemcjit;
     char *cmd_line_chunk;
 } terra_Options;
 int terra_initwithoptions(lua_State *L, terra_Options *options);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -138,7 +138,6 @@ void usage() {
            "    -g enable debugging symbols\n"
            "    -h print this help message\n"
            "    -i enter the REPL after processing source files\n"
-           "    -m use LLVM's MCJIT\n"
            "    -e 'chunk' : execute command-line 'chunk' of code\n"
            "    -  Execute stdin instead of script and stop parsing options\n");
 }
@@ -150,12 +149,11 @@ void parse_args(lua_State *L, int argc, char **argv, terra_Options *options,
                                        {"verbose", 0, NULL, 'v'},
                                        {"debugsymbols", 0, NULL, 'g'},
                                        {"interactive", 0, NULL, 'i'},
-                                       {"mcjit", 0, NULL, 'm'},
                                        {"execute", required_argument, NULL, 'e'},
                                        {NULL, 0, NULL, 0}};
     /*  Parse commandline options  */
     opterr = 0;
-    while ((ch = getopt_long(argc, argv, "+hvgime:p:", longopts, NULL)) != -1) {
+    while ((ch = getopt_long(argc, argv, "+hvgie:p:", longopts, NULL)) != -1) {
         switch (ch) {
             case 'v':
                 options->verbose++;
@@ -165,9 +163,6 @@ void parse_args(lua_State *L, int argc, char **argv, terra_Options *options,
                 break;
             case 'g':
                 options->debug++;
-                break;
-            case 'm':
-                options->usemcjit = 1;
                 break;
             case 'e':
                 options->cmd_line_chunk = (char *)malloc(strlen(optarg) + 1);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -358,8 +358,7 @@ int terra_initcompilationunit(lua_State *L) {
 
 static void InitializeJIT(TerraCompilationUnit *CU) {
     if (CU->ee) return;  // already initialized
-    Module *topeemodule =
-            new Module("terra", *CU->TT->ctx);
+    Module *topeemodule = new Module("terra", *CU->TT->ctx);
 #ifdef _WIN32
     std::string MCJITTriple = CU->TT->Triple;
     MCJITTriple.append("-elf");  // on windows we need to use an elf container because
@@ -440,7 +439,7 @@ static void freecompilationunit(TerraCompilationUnit *CU) {
             delete CU->jiteventlistener;
             delete CU->ee;
         }
-        delete CU->M; // we own the module so we delete it
+        delete CU->M;  // we own the module so we delete it
         freetarget(CU->TT);
         terra_compilerfree(CU->C);  // decrement reference count to compiler
         delete CU;
@@ -2989,8 +2988,7 @@ static void *JITGlobalValue(TerraCompilationUnit *CU, GlobalValue *gv) {
     ExecutionEngine *ee = CU->ee;
     if (gv->isDeclaration()) {
         StringRef name = gv->getName();
-        if (name.startswith(
-                    "\01"))  // remove asm renaming tag before looking for symbol
+        if (name.startswith("\01"))  // remove asm renaming tag before looking for symbol
             name = name.substr(1);
         return ee->getPointerToNamedFunction(name);
     }
@@ -2999,16 +2997,15 @@ static void *JITGlobalValue(TerraCompilationUnit *CU, GlobalValue *gv) {
         return ptr;
     }
     llvm::ValueToValueMapTy VMap;
-    Module *m = llvmutil_extractmodulewithproperties(
-            gv->getName(), gv->getParent(), &gv, 1, MCJITShouldCopy, CU, VMap);
+    Module *m = llvmutil_extractmodulewithproperties(gv->getName(), gv->getParent(), &gv,
+                                                     1, MCJITShouldCopy, CU, VMap);
 
     if (CU->T->options.debug > 1) {
         llvm::SmallString<256> tmpname;
         llvmutil_createtemporaryfile("terra", "so", tmpname);
         if (SaveSharedObject(CU, m, NULL, tmpname.c_str())) lua_error(CU->T->L);
         sys::DynamicLibrary::LoadLibraryPermanently(tmpname.c_str());
-        void *result =
-                sys::DynamicLibrary::SearchForAddressOfSymbol(gv->getName().str());
+        void *result = sys::DynamicLibrary::SearchForAddressOfSymbol(gv->getName().str());
         assert(result);
         return result;
     }
@@ -3043,7 +3040,7 @@ static int terra_deletefunction(lua_State *L) {
     // for MCJIT, we need to keep the declaration so
     // another function doesn't get the same name
     VERBOSE_ONLY(CU->T) {
-      printf("... uses not empty, removing body but keeping declaration.\n");
+        printf("... uses not empty, removing body but keeping declaration.\n");
     }
     func->deleteBody();
     VERBOSE_ONLY(CU->T) { printf("... finish delete.\n"); }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -359,7 +359,7 @@ int terra_initcompilationunit(lua_State *L) {
 static void InitializeJIT(TerraCompilationUnit *CU) {
     if (CU->ee) return;  // already initialized
     Module *topeemodule =
-            (CU->T->options.usemcjit) ? new Module("terra", *CU->TT->ctx) : CU->M;
+            new Module("terra", *CU->TT->ctx);
 #ifdef _WIN32
     std::string MCJITTriple = CU->TT->Triple;
     MCJITTriple.append("-elf");  // on windows we need to use an elf container because
@@ -414,7 +414,6 @@ int terra_compilerinit(struct terra_State *T) {
     T->C = new terra_CompilerState();
     memset(T->C, 0, sizeof(terra_CompilerState));
     T->C->nreferences = 1;
-    T->options.usemcjit = 1;  // force mcjit use, since old JIT is no longer supported.
     return 0;
 }
 void freetarget(TerraTarget *TT) {
@@ -441,8 +440,7 @@ static void freecompilationunit(TerraCompilationUnit *CU) {
             delete CU->jiteventlistener;
             delete CU->ee;
         }
-        if (CU->T->options.usemcjit || !CU->ee)  // we own the module so we delete it
-            delete CU->M;
+        delete CU->M; // we own the module so we delete it
         freetarget(CU->TT);
         terra_compilerfree(CU->C);  // decrement reference count to compiler
         delete CU;
@@ -2989,37 +2987,33 @@ static bool SaveSharedObject(TerraCompilationUnit *CU, Module *M,
 static void *JITGlobalValue(TerraCompilationUnit *CU, GlobalValue *gv) {
     InitializeJIT(CU);
     ExecutionEngine *ee = CU->ee;
-    if (CU->T->options.usemcjit) {
-        if (gv->isDeclaration()) {
-            StringRef name = gv->getName();
-            if (name.startswith(
-                        "\01"))  // remove asm renaming tag before looking for symbol
-                name = name.substr(1);
-            return ee->getPointerToNamedFunction(name);
-        }
-        void *ptr = GetGlobalValueAddress(CU, gv->getName());
-        if (ptr) {
-            return ptr;
-        }
-        llvm::ValueToValueMapTy VMap;
-        Module *m = llvmutil_extractmodulewithproperties(
-                gv->getName(), gv->getParent(), &gv, 1, MCJITShouldCopy, CU, VMap);
-
-        if (CU->T->options.debug > 1) {
-            llvm::SmallString<256> tmpname;
-            llvmutil_createtemporaryfile("terra", "so", tmpname);
-            if (SaveSharedObject(CU, m, NULL, tmpname.c_str())) lua_error(CU->T->L);
-            sys::DynamicLibrary::LoadLibraryPermanently(tmpname.c_str());
-            void *result =
-                    sys::DynamicLibrary::SearchForAddressOfSymbol(gv->getName().str());
-            assert(result);
-            return result;
-        }
-        ee->addModule(UNIQUEIFY(Module, m));
-        return (void *)ee->getGlobalValueAddress(gv->getName().str());
-    } else {
-        return ee->getPointerToGlobal(gv);
+    if (gv->isDeclaration()) {
+        StringRef name = gv->getName();
+        if (name.startswith(
+                    "\01"))  // remove asm renaming tag before looking for symbol
+            name = name.substr(1);
+        return ee->getPointerToNamedFunction(name);
     }
+    void *ptr = GetGlobalValueAddress(CU, gv->getName());
+    if (ptr) {
+        return ptr;
+    }
+    llvm::ValueToValueMapTy VMap;
+    Module *m = llvmutil_extractmodulewithproperties(
+            gv->getName(), gv->getParent(), &gv, 1, MCJITShouldCopy, CU, VMap);
+
+    if (CU->T->options.debug > 1) {
+        llvm::SmallString<256> tmpname;
+        llvmutil_createtemporaryfile("terra", "so", tmpname);
+        if (SaveSharedObject(CU, m, NULL, tmpname.c_str())) lua_error(CU->T->L);
+        sys::DynamicLibrary::LoadLibraryPermanently(tmpname.c_str());
+        void *result =
+                sys::DynamicLibrary::SearchForAddressOfSymbol(gv->getName().str());
+        assert(result);
+        return result;
+    }
+    ee->addModule(UNIQUEIFY(Module, m));
+    return (void *)ee->getGlobalValueAddress(gv->getName().str());
 }
 
 static int terra_jit(lua_State *L) {
@@ -3045,16 +3039,13 @@ static int terra_deletefunction(lua_State *L) {
         printf("deleting function: %s\n", func->getName().str().c_str());
     }
     // MCJIT can't free individual functions, so we need to leak the generated code
-    if (!func->use_empty() ||
-        CU->T->options.usemcjit) {  // for MCJIT, we need to keep the declaration so
-                                    // another function doesn't get the same name
-        VERBOSE_ONLY(CU->T) {
-            printf("... uses not empty, removing body but keeping declaration.\n");
-        }
-        func->deleteBody();
-    } else {
-        CU->mi->eraseFunction(func);
+
+    // for MCJIT, we need to keep the declaration so
+    // another function doesn't get the same name
+    VERBOSE_ONLY(CU->T) {
+      printf("... uses not empty, removing body but keeping declaration.\n");
     }
+    func->deleteBody();
     VERBOSE_ONLY(CU->T) { printf("... finish delete.\n"); }
     fstate->func = NULL;
     freecompilationunit(CU);

--- a/src/terra.cpp
+++ b/src/terra.cpp
@@ -412,9 +412,6 @@ int terra_initwithoptions(lua_State *L, terra_Options *options) {
     memset(T, 0, sizeof(terra_State));  // some of lua stuff expects pointers to be null
                                         // on entry
     T->options = *options;
-#ifdef __arm__
-    T->options.usemcjit = true;  // force MCJIT since old JIT is partially broken on ARM
-#endif
     T->numlivefunctions = 1;
     T->L = L;
     assert(T->L);
@@ -608,7 +605,6 @@ extern "C" int luaopen_terra(lua_State *L) {
     memset(&options, 0, sizeof(terra_Options));
     if (!lua_isnil(L, 1)) options.verbose = lua_tonumber(L, 1);
     if (!lua_isnil(L, 2)) options.debug = lua_tonumber(L, 2);
-    if (!lua_isnil(L, 3)) options.usemcjit = lua_tonumber(L, 3);
     if (terra_initwithoptions(L, &options)) lua_error(L);
     return 0;
 }


### PR DESCRIPTION
Removing more dead code thanks to the removal of LLVM <= 3.7 support.