### PR TITLE
Fix linker detection and workaround CPU detection

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -271,6 +271,10 @@ int terra_inittarget(lua_State *L) {
     else
         TT->CPU = llvm::sys::getHostCPUName().str();
 
+    if (TT->CPU == "generic") {
+        TT->CPU = "x86-64";
+    }
+
     if (!lua_isnil(L, 3))
         TT->Features = lua_tostring(L, 3);
     else {
@@ -3065,7 +3069,10 @@ static int terra_disassemble(lua_State *L) {
 
 static bool FindLinker(terra_State *T, LLVM_PATH_TYPE *linker, const char *target) {
 #ifndef _WIN32
-    *linker = *sys::findProgramByName("gcc");
+    const char *linker_name = getenv("CC");
+    if (!linker_name) linker_name = getenv("CXX");
+    if (!linker_name) linker_name = "gcc";
+    *linker = *sys::findProgramByName(linker_name);
     return *linker == "";
 #else
     lua_getfield(T->L, LUA_GLOBALSINDEX, "terra");


### PR DESCRIPTION
This is an incremental change, isolating the fix for identifying the linker properly, and the work around for the bug in LLVM's CPU detection. 