### PR TITLE
Fix conversions to logical primitive types

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1044,7 +1044,11 @@ struct CCallingConv {
     PointerType *Ptr(Type *t) { return PointerType::getUnqual(t); }
     Value *ConvertPrimitive(IRBuilder<> *B, Value *src, Type *dstType, bool issigned) {
         if (!dstType->isIntegerTy()) return src;
-        return B->CreateIntCast(src, dstType, issigned);
+        if (dstType == Type::getInt1Ty(*CU->TT->ctx)) {
+            return B->CreateICmpNE(src, ConstantInt::get(src->getType(), 0));
+        } else {
+            return B->CreateIntCast(src, dstType, issigned);
+        }
     }
     void EmitEntry(IRBuilder<> *B, Obj *ftype, Function *func,
                    std::vector<Value *> *variables) {
@@ -1808,7 +1812,12 @@ struct FunctionEmitter {
 
         if (fBase->isIntegerTy()) {
             if (tBase->isIntegerTy()) {
-                return B->CreateIntCast(exp, to->type, from->issigned);
+                if (to->islogical) {
+                    return B->CreateZExt(B->CreateICmpNE(exp, ConstantInt::get(fBase, 0)),
+                                         tBase);
+                } else {
+                    return B->CreateIntCast(exp, to->type, from->issigned);
+                }
             } else if (tBase->isFloatingPointTy()) {
                 if (from->issigned) {
                     return B->CreateSIToFP(exp, to->type);

--- a/tests/boolcast.t
+++ b/tests/boolcast.t
@@ -1,0 +1,14 @@
+terra f1(x : int64)
+    return [bool](x)
+end
+
+terra f2(x : int64)
+    return not [bool](x)
+end
+
+assert(not f1(0))
+assert(f2(0))
+for _, x in ipairs({-2,-1,1,2,3,4,16,256,65536,4294967296}) do
+    assert(f1(x))
+    assert(not f2(x))
+end


### PR DESCRIPTION
This appears to fix #460. In the function without `not`, the argument is converted from `int32` to logical `int8` to `bool`. In the function with `not`, the argument is converted from `int32` to logical `int8`, the `not` operator is applied, and the result is converted from logical `int8` to `bool`; the operator ensures that only 0 or 1 will be converted to `bool`. The incorrect results are caused by primitive values being truncated when converted to smaller logical primitive types, instead of being compared against 0.

In this commit, the change in `emitPrimitiveCast` fixes the `int32` to logical `int8` conversion, so that `[bool](256)` does not equal `false`. Similarly, the change in `ConvertPrimitive` fixes the logical `int8` to `bool` conversion, so that `[bool](2)` does not equal `false`. Both comparison expressions were adapted from the `T_not` conversion on line 1542.

Should I add any new tests for this?