### PR TITLE
Update CI tests (except for LLVM 3.8) to Ubuntu 18.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 jobs:
   check_format:
     name: Check Format
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-16.04', 'macos-10.15']
+        os: ['ubuntu-16.04', 'ubuntu-18.04', 'macos-10.15']
         llvm: ['3.8', '5.0', '6.0', '7', '8', '9', '10', '11']
         cmake: ['0', '1']
         cuda: ['0', '1']
@@ -23,6 +23,24 @@ jobs:
         slib: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
+          # LLVM 3.8 only on Ubuntu 16.04, all others on Ubuntu 18.04
+          - os: 'ubuntu-16.04'
+            llvm: '5.0'
+          - os: 'ubuntu-16.04'
+            llvm: '6.0'
+          - os: 'ubuntu-16.04'
+            llvm: '7'
+          - os: 'ubuntu-16.04'
+            llvm: '8'
+          - os: 'ubuntu-16.04'
+            llvm: '9'
+          - os: 'ubuntu-16.04'
+            llvm: '10'
+          - os: 'ubuntu-16.04'
+            llvm: '11'
+          - os: 'ubuntu-18.04'
+            llvm: '3.8'
+
           # macOS: exclude LLVM 5.0, 8-11 make, cuda/no-static/no-slib
           - os: 'macos-10.15'
             llvm: '5.0'

--- a/travis.sh
+++ b/travis.sh
@@ -197,7 +197,7 @@ if [[ $USE_CMAKE -eq 1 ]]; then
   fi
 
   # Only deploy CMake builds, and only with LLVM 9.
-  if [[ $LLVM_CONFIG = llvm-config-9 && $USE_CUDA -eq 1 && $TERRA_LUA = luajit ]]; then
+  if [[ $LLVM_CONFIG = llvm-config-9 && $SLIB_INCLUDE_LLVM -eq 1 && $USE_CUDA -eq 1 && $TERRA_LUA = luajit ]]; then
     RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/`-`uname -m`-`git rev-parse --short HEAD`
     mv install $RELEASE_NAME
     zip -q -r $RELEASE_NAME.zip $RELEASE_NAME

--- a/travis.sh
+++ b/travis.sh
@@ -5,9 +5,6 @@ set -x
 
 if [[ $CHECK_CLANG_FORMAT -eq 1 ]]; then
     if [[ $(uname) = Linux ]]; then
-        wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-        sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
-        for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
         sudo apt-get install -y clang-format-9
         export PATH="/usr/lib/llvm-9/bin:$PATH"
     else
@@ -31,7 +28,7 @@ if [[ $(uname) = Linux ]]; then
   sudo apt-get update -qq
   if [[ $LLVM_CONFIG = llvm-config-11 ]]; then
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-11 main"
+    sudo add-apt-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
     for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-11-dev clang-11 libclang-11-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-11:/usr/share/llvm-11
@@ -39,36 +36,15 @@ if [[ $(uname) = Linux ]]; then
         export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/llvm-11/lib"
     fi
   elif [[ $LLVM_CONFIG = llvm-config-10 ]]; then
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-10 main"
-    for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-10-dev clang-10 libclang-10-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-10:/usr/share/llvm-10
-    if [[ -n $STATIC_LLVM && $STATIC_LLVM -eq 0 ]]; then
-        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/llvm-10/lib"
-    fi
   elif [[ $LLVM_CONFIG = llvm-config-9 ]]; then
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-9 main"
-    for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-9-dev clang-9 libclang-9-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-9:/usr/share/llvm-9
-    if [[ -n $STATIC_LLVM && $STATIC_LLVM -eq 0 ]]; then
-        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/llvm-9/lib"
-    fi
   elif [[ $LLVM_CONFIG = llvm-config-8 ]]; then
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-8 main"
-    for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-8-dev clang-8 libclang-8-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-8:/usr/share/llvm-8
-    if [[ -n $STATIC_LLVM && $STATIC_LLVM -eq 0 ]]; then
-        export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/llvm-8/lib"
-    fi
   elif [[ $LLVM_CONFIG = llvm-config-7 ]]; then
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
-    for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-7-dev clang-7 libclang-7-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-7:/usr/share/llvm-7
   elif [[ $LLVM_CONFIG = llvm-config-6.0 ]]; then
@@ -91,7 +67,8 @@ if [[ $(uname) = Linux ]]; then
     sudo apt-get install -y llvm-3.8-dev clang-3.8 libclang-3.8-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/share/llvm-3.8
   else
-    sudo apt-get install -qq llvm-3.5-dev clang-3.5 libclang-3.5-dev
+    echo "Don't know this LLVM version: $LLVM_CONFIG"
+    exit 1
   fi
 
   if [[ $USE_CUDA -eq 1 ]]; then
@@ -153,10 +130,8 @@ if [[ $(uname) = Darwin ]]; then
     ln -s clang+llvm-3.8.0-x86_64-apple-darwin/bin/clang clang-3.8
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-3.8.0-x86_64-apple-darwin
   else
-    curl -L -O http://releases.llvm.org/3.5.2/clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-3.5.2-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/llvm-config llvm-config-3.5
-    ln -s clang+llvm-3.5.2-x86_64-apple-darwin/bin/clang clang-3.5
+    echo "Don't know this LLVM version: $LLVM_CONFIG"
+    exit 1
   fi
 
   if [[ $USE_CUDA -eq 1 ]]; then


### PR DESCRIPTION
Partly this is to keep us (mostly) off of unsupported Ubuntu releases, and partly this helps pave the way for LLVM 12.