### PR TITLE
Test LLVM 3.8 via Docker since it's not available in newer Ubuntu

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,36 +15,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-16.04', 'ubuntu-18.04', 'macos-10.15']
-        llvm: ['3.8', '5.0', '6.0', '7', '8', '9', '10', '11', '12', '13']
+        os: ['ubuntu-18.04', 'macos-10.15']
+        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12', '13']
         cmake: ['0', '1']
         cuda: ['0', '1']
         static: ['0', '1']
         slib: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
-          # LLVM 3.8 only on Ubuntu 16.04, all others on Ubuntu 18.04
-          - os: 'ubuntu-16.04'
-            llvm: '5.0'
-          - os: 'ubuntu-16.04'
-            llvm: '6.0'
-          - os: 'ubuntu-16.04'
-            llvm: '7'
-          - os: 'ubuntu-16.04'
-            llvm: '8'
-          - os: 'ubuntu-16.04'
-            llvm: '9'
-          - os: 'ubuntu-16.04'
-            llvm: '10'
-          - os: 'ubuntu-16.04'
-            llvm: '11'
-          - os: 'ubuntu-16.04'
-            llvm: '12'
-          - os: 'ubuntu-16.04'
-            llvm: '13'
-          - os: 'ubuntu-18.04'
-            llvm: '3.8'
-
           # macOS: exclude LLVM 5.0, 8-13 make, cuda/no-static/no-slib
           - os: 'macos-10.15'
             llvm: '5.0'
@@ -99,8 +77,6 @@ jobs:
             lua: 'moonjit'
 
           # CUDA: only LLVM 9
-          - llvm: '3.8'
-            cuda: '1'
           - llvm: '5.0'
             cuda: '1'
           - llvm: '6.0'
@@ -119,8 +95,6 @@ jobs:
             cuda: '1'
 
           # no-static: only LLVM 8
-          - llvm: '3.8'
-            static: '0'
           - llvm: '5.0'
             static: '0'
           - llvm: '6.0'
@@ -139,8 +113,6 @@ jobs:
             static: '0'
 
           # no-slib: only LLVM 9
-          - llvm: '3.8'
-            slib: '0'
           - llvm: '5.0'
             slib: '0'
           - llvm: '6.0'
@@ -159,8 +131,6 @@ jobs:
             slib: '0'
 
           # Moonjit: only LLVM 9
-          - llvm: '3.8'
-            lua: 'moonjit'
           - llvm: '5.0'
             lua: 'moonjit'
           - llvm: '6.0'
@@ -200,12 +170,19 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: [ubuntu-16.04, ubuntu-18.04, ubuntu-20.04]
+        distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04']
+        llvm: ['3.8', '6.0']
+        exclude:
+          - distro: 'ubuntu-18.04'
+            llvm: '3.8'
+          - distro: 'ubuntu-20.04'
+            llvm: '3.8'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh
         env:
           DOCKER_BUILD: ${{ matrix.distro }}
+          DOCKER_LLVM: ${{ matrix.llvm }}
   nix:
     name: Nix Build (nixpkgs-${{ matrix.nixpkgs }}, enableCUDA=${{ matrix.cuda }})
     runs-on: ubuntu-latest

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -8,7 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY . /terra
 
 RUN apt-get update -qq && \
-    apt-get install -qq build-essential cmake git llvm-$llvm-dev libclang-$llvm-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
+    apt-get install -qq build-essential cmake git llvm-${llvm}-dev libclang-${llvm}-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
     cd /terra/build && \
     cmake -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
     make install -j4 && \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,4 +1,5 @@
 ARG release=16.04
+ARG llvm=6.0
 
 FROM ubuntu:$release
 
@@ -7,7 +8,7 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY . /terra
 
 RUN apt-get update -qq && \
-    apt-get install -qq build-essential cmake git llvm-6.0-dev libclang-6.0-dev clang-6.0 libedit-dev libncurses5-dev zlib1g-dev && \
+    apt-get install -qq build-essential cmake git llvm-$llvm-dev libclang-$llvm-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
     cd /terra/build && \
     cmake -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
     make install -j4 && \

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -1,14 +1,15 @@
 ARG release=16.04
-ARG llvm=6.0
 
 FROM ubuntu:$release
+
+ARG llvm=6.0
 
 ENV DEBIAN_FRONTEND noninteractive
 
 COPY . /terra
 
 RUN apt-get update -qq && \
-    apt-get install -qq build-essential cmake git llvm-${llvm}-dev libclang-${llvm}-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
+    apt-get install -qq build-essential cmake git llvm-$llvm-dev libclang-$llvm-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
     cd /terra/build && \
     cmake -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
     make install -j4 && \

--- a/docker/Dockerfile.ubuntu-upstream
+++ b/docker/Dockerfile.ubuntu-upstream
@@ -1,0 +1,28 @@
+ARG release=16.04
+
+FROM ubuntu:$release
+
+ARG llvm=6.0
+
+ENV DEBIAN_FRONTEND noninteractive
+
+COPY . /terra
+
+RUN apt-get update -qq && \
+    apt-get install -qq wget software-properties-common apt-transport-https ca-certificates && \
+    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
+    . /etc/lsb-release && \
+    add-apt-repository -y "deb http://apt.llvm.org/$DISTRIB_CODENAME/ llvm-toolchain-$DISTRIB_CODENAME-$llvm main" && \
+    apt-get update -qq && \
+    echo 'Package: *' >> /etc/apt/preferences.d/llvm-600 && \
+    echo 'Pin: origin apt.llvm.org' >> /etc/apt/preferences.d/llvm-600 && \
+    echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/llvm-600 && \
+    apt-get install -qq build-essential cmake git llvm-$llvm-dev libclang-$llvm-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
+    cd /terra/build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
+    make install -j4 && \
+    ctest --output-on-failure -j4
+
+FROM ubuntu:$release
+
+COPY --from=0 /terra_install/* /usr/local/

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,5 +3,6 @@
 set -e
 
 IFS=- read distro release <<< "$1"
+llvm="$2"
 
-docker build --build-arg release=$release -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro .
+docker build --build-arg release=$release --build-arg llvm=$llvm -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,5 +4,6 @@ set -e
 
 IFS=- read distro release <<< "$1"
 llvm="$2"
+variant="$3"
 
-docker build --build-arg release=$release --build-arg llvm=$llvm -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro .
+docker build --build-arg release=$release --build-arg llvm=$llvm -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro${variant+-}$variant .

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -6,4 +6,4 @@ IFS=- read distro release <<< "$1"
 llvm="$2"
 variant="$3"
 
-docker build --build-arg release=$release --build-arg llvm=$llvm -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro${variant+-}$variant .
+docker build --build-arg release=$release --build-arg llvm=$llvm -t terralang/terra:$distro-$release -f docker/Dockerfile.$distro${variant:+-}$variant .

--- a/travis.sh
+++ b/travis.sh
@@ -20,7 +20,7 @@ if [[ $CHECK_CLANG_FORMAT -eq 1 ]]; then
 fi
 
 if [[ -n $DOCKER_BUILD ]]; then
-    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM
+    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM $( [[ $DOCKER_LLVM = "3.8" ]] && echo upstream )
     exit 0
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -20,7 +20,7 @@ if [[ $CHECK_CLANG_FORMAT -eq 1 ]]; then
 fi
 
 if [[ -n $DOCKER_BUILD ]]; then
-    ./docker/build.sh $DOCKER_BUILD
+    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM
     exit 0
 fi
 
@@ -71,19 +71,6 @@ if [[ $(uname) = Linux ]]; then
   elif [[ $LLVM_CONFIG = llvm-config-5.0 ]]; then
     sudo apt-get install -qq llvm-5.0-dev clang-5.0 libclang-5.0-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-5.0:/usr/share/llvm-5.0
-  elif [[ $LLVM_CONFIG = llvm-config-3.8 ]]; then
-    wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-3.8 main"
-    for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
-    sudo bash -c "echo 'Package: *' >> /etc/apt/preferences.d/llvm-600"
-    sudo bash -c "echo 'Pin: origin apt.llvm.org' >> /etc/apt/preferences.d/llvm-600"
-    sudo bash -c "echo 'Pin-Priority: 600' >> /etc/apt/preferences.d/llvm-600"
-    cat /etc/apt/preferences.d/llvm-600
-    apt-cache policy llvm-3.8-dev
-    # Travis has LLVM pre-installed, and it's on the wrong version...
-    sudo apt-get autoremove -y llvm-3.8
-    sudo apt-get install -y llvm-3.8-dev clang-3.8 libclang-3.8-dev libedit-dev
-    export CMAKE_PREFIX_PATH=/usr/share/llvm-3.8
   else
     echo "Don't know this LLVM version: $LLVM_CONFIG"
     exit 1


### PR DESCRIPTION
Fixes #506 

This is an alternative to #511 since Ubuntu 18.04 does not have LLVM 3.8 in the repositories and the official binaries on llvm.org are broken on the newer distro. Instead of building LLVM 3.8 on the Actions runner directly, build it in Docker so that we don't rely on the available Actions environments for coverage.