### PR TITLE
Add support for setting calling convention on functions

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -278,6 +278,18 @@ Get or set the pretty name for the function. This is useful when viewing generat
 
 When `true` function when be always inlined. When `false` the function will never be inlined. By default, functions will be inlined at the discretion of LLVM's function inliner.
 
+---
+
+    func:setoptimized(bool)
+
+All Terra functions are optimized by default (equivalent of Clang `-O3`). Pass `false` to this method to disable optimization (equivalent of Clang `-O0`).
+
+---
+
+    func:setcallingconv(string)
+
+Set the calling convention of the function. LLVM's default calling convention is used by default. Valid values are the same as can be specified in [LLVM's text-based assembly language](https://llvm.org/docs/LangRef.html#calling-conventions). (Note that, as of the time of writing, the official LLVM documentation is incomplete, particularly for target-specific calling conventions. For additional calling conventions, it may be necessary to consult the [source code directly](https://github.com/llvm/llvm-project/blob/llvmorg-13.0.0/llvm/lib/IR/AsmWriter.cpp#L289-L339).)
+
 Types
 -----
 

--- a/src/llvmheaders_100.h
+++ b/src/llvmheaders_100.h
@@ -31,7 +31,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_100.h
+++ b/src/llvmheaders_100.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_110.h
+++ b/src/llvmheaders_110.h
@@ -31,7 +31,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_110.h
+++ b/src/llvmheaders_110.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_120.h
+++ b/src/llvmheaders_120.h
@@ -31,7 +31,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_120.h
+++ b/src/llvmheaders_120.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_130.h
+++ b/src/llvmheaders_130.h
@@ -31,7 +31,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::OF_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::OF_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_130.h
+++ b/src/llvmheaders_130.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_38.h
+++ b/src/llvmheaders_38.h
@@ -25,7 +25,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_38.h
+++ b/src/llvmheaders_38.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_39.h
+++ b/src/llvmheaders_39.h
@@ -25,7 +25,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_39.h
+++ b/src/llvmheaders_39.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_50.h
+++ b/src/llvmheaders_50.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_50.h
+++ b/src/llvmheaders_50.h
@@ -27,7 +27,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_60.h
+++ b/src/llvmheaders_60.h
@@ -30,7 +30,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_60.h
+++ b/src/llvmheaders_60.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_70.h
+++ b/src/llvmheaders_70.h
@@ -30,7 +30,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_70.h
+++ b/src/llvmheaders_70.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_80.h
+++ b/src/llvmheaders_80.h
@@ -31,7 +31,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_80.h
+++ b/src/llvmheaders_80.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/llvmheaders_90.h
+++ b/src/llvmheaders_90.h
@@ -31,7 +31,3 @@
 #define LLVM_PATH_TYPE std::string
 #define RAW_FD_OSTREAM_NONE sys::fs::F_None
 #define RAW_FD_OSTREAM_BINARY sys::fs::F_None
-#define HASFNATTR(attr) \
-    getAttributes().hasAttribute(AttributeSet::FunctionIndex, Attribute ::attr)
-#define ADDFNATTR(attr) addFnAttr(Attribute ::attr)
-#define ATTRIBUTE Attributes

--- a/src/llvmheaders_90.h
+++ b/src/llvmheaders_90.h
@@ -1,3 +1,4 @@
+#include "llvm/IR/CallingConv.h"
 #include "llvm/IR/DerivedTypes.h"
 #include "llvm/IR/LLVMContext.h"
 #include "llvm/IR/Module.h"

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1288,8 +1288,7 @@ static GlobalVariable *EmitGlobalVariable(TerraCompilationUnit *CU, Obj *global,
 
 static CallingConv::ID ParseCallingConv(const char *cc) {
     // LLVM does not provide a way to parse this programmatically, so
-    // we're just going to replicate the table from:
-    // https://github.com/llvm/llvm-project/blob/61814586620deca51ecf6477e19c6afa8e28ad90/llvm/lib/IR/AsmWriter.cpp#L290
+    // we're just going to replicate the table from llvm/lib/IR/AsmWriter.cpp
     static std::map<std::string, CallingConv::ID> ccmap;
     static bool init = false;
     if (!init) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1302,8 +1302,10 @@ static CallingConv::ID ParseCallingConv(const char *cc) {
         ccmap["preserve_allcc"] = CallingConv::PreserveAll;
         ccmap["cxx_fast_tlscc"] = CallingConv::CXX_FAST_TLS;
         ccmap["ghccc"] = CallingConv::GHC;
+#if LLVM_VERSION >= 100
         ccmap["tailcc"] = CallingConv::Tail;
         ccmap["cfguard_checkcc"] = CallingConv::CFGuard_Check;
+#endif
         ccmap["x86_stdcallcc"] = CallingConv::X86_StdCall;
         ccmap["x86_fastcallcc"] = CallingConv::X86_FastCall;
         ccmap["x86_thiscallcc"] = CallingConv::X86_ThisCall;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1378,20 +1378,20 @@ struct FunctionEmitter {
 
             if (funcobj->hasfield("alwaysinline")) {
                 if (funcobj->boolean("alwaysinline")) {
-                    fstate->func->ADDFNATTR(AlwaysInline);
+                    fstate->func->addFnAttr(Attribute::AlwaysInline);
                 } else {
-                    fstate->func->ADDFNATTR(NoInline);
+                    fstate->func->addFnAttr(Attribute::NoInline);
                 }
             }
             if (funcobj->hasfield("dontoptimize")) {
                 if (funcobj->boolean("dontoptimize")) {
-                    fstate->func->ADDFNATTR(OptimizeNone);
-                    fstate->func->ADDFNATTR(NoInline);
+                    fstate->func->addFnAttr(Attribute::OptimizeNone);
+                    fstate->func->addFnAttr(Attribute::NoInline);
                 }
             }
             if (funcobj->hasfield("noreturn")) {
                 if (funcobj->boolean("noreturn")) {
-                    fstate->func->ADDFNATTR(NoReturn);
+                    fstate->func->addFnAttr(Attribute::NoReturn);
                 }
             }
 

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1326,8 +1326,8 @@ static CallingConv::ID ParseCallingConv(const char *cc) {
         ccmap["msp430_intrcc"] = CallingConv::MSP430_INTR;
 #if LLVM_VERSION >= 39
         ccmap["avr_intrcc"] = CallingConv::AVR_INTR;
-#endif
         ccmap["avr_signalcc"] = CallingConv::AVR_SIGNAL;
+#endif
         ccmap["ptx_kernel"] = CallingConv::PTX_Kernel;
         ccmap["ptx_device"] = CallingConv::PTX_Device;
         ccmap["x86_64_sysvcc"] = CallingConv::X86_64_SysV;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1313,8 +1313,12 @@ static CallingConv::ID ParseCallingConv(const char *cc) {
         ccmap["arm_apcscc"] = CallingConv::ARM_APCS;
         ccmap["arm_aapcscc"] = CallingConv::ARM_AAPCS;
         ccmap["arm_aapcs_vfpcc"] = CallingConv::ARM_AAPCS_VFP;
+#if LLVM_VERSION >= 80
         ccmap["aarch64_vector_pcs"] = CallingConv::AArch64_VectorCall;
+#endif
+#if LLVM_VERSION >= 100
         ccmap["aarch64_sve_vector_pcs"] = CallingConv::AArch64_SVE_VectorCall;
+#endif
         ccmap["msp430_intrcc"] = CallingConv::MSP430_INTR;
         ccmap["avr_intrcc"] = CallingConv::AVR_INTR;
         ccmap["avr_signalcc"] = CallingConv::AVR_SIGNAL;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1309,7 +1309,9 @@ static CallingConv::ID ParseCallingConv(const char *cc) {
         ccmap["x86_stdcallcc"] = CallingConv::X86_StdCall;
         ccmap["x86_fastcallcc"] = CallingConv::X86_FastCall;
         ccmap["x86_thiscallcc"] = CallingConv::X86_ThisCall;
+#if LLVM_VERSION >= 40
         ccmap["x86_regcallcc"] = CallingConv::X86_RegCall;
+#endif
         ccmap["x86_vectorcallcc"] = CallingConv::X86_VectorCall;
         ccmap["intel_ocl_bicc"] = CallingConv::Intel_OCL_BI;
         ccmap["arm_apcscc"] = CallingConv::ARM_APCS;
@@ -1322,12 +1324,16 @@ static CallingConv::ID ParseCallingConv(const char *cc) {
         ccmap["aarch64_sve_vector_pcs"] = CallingConv::AArch64_SVE_VectorCall;
 #endif
         ccmap["msp430_intrcc"] = CallingConv::MSP430_INTR;
+#if LLVM_VERSION >= 39
         ccmap["avr_intrcc"] = CallingConv::AVR_INTR;
+#endif
         ccmap["avr_signalcc"] = CallingConv::AVR_SIGNAL;
         ccmap["ptx_kernel"] = CallingConv::PTX_Kernel;
         ccmap["ptx_device"] = CallingConv::PTX_Device;
         ccmap["x86_64_sysvcc"] = CallingConv::X86_64_SysV;
+#if LLVM_VERSION >= 50
         ccmap["win64cc"] = CallingConv::Win64;
+#endif
         ccmap["spir_func"] = CallingConv::SPIR_FUNC;
         ccmap["spir_kernel"] = CallingConv::SPIR_KERNEL;
         ccmap["swiftcc"] = CallingConv::Swift;
@@ -1337,14 +1343,22 @@ static CallingConv::ID ParseCallingConv(const char *cc) {
         ccmap["x86_intrcc"] = CallingConv::X86_INTR;
         ccmap["hhvmcc"] = CallingConv::HHVM;
         ccmap["hhvm_ccc"] = CallingConv::HHVM_C;
+#if LLVM_VERSION >= 39
         ccmap["amdgpu_vs"] = CallingConv::AMDGPU_VS;
+#if LLVM_VERSION >= 60
         ccmap["amdgpu_ls"] = CallingConv::AMDGPU_LS;
+#endif
+#if LLVM_VERSION >= 50
         ccmap["amdgpu_hs"] = CallingConv::AMDGPU_HS;
+#endif
+#if LLVM_VERSION >= 60
         ccmap["amdgpu_es"] = CallingConv::AMDGPU_ES;
+#endif
         ccmap["amdgpu_gs"] = CallingConv::AMDGPU_GS;
         ccmap["amdgpu_ps"] = CallingConv::AMDGPU_PS;
         ccmap["amdgpu_cs"] = CallingConv::AMDGPU_CS;
         ccmap["amdgpu_kernel"] = CallingConv::AMDGPU_KERNEL;
+#endif
 #if LLVM_VERSION >= 120
         ccmap["amdgpu_gfx"] = CallingConv::AMDGPU_Gfx;
 #endif

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -557,6 +557,10 @@ function T.terrafunction:setoptimized(v)
     assert(not (self.definition.alwaysinline and self.definition.dontoptimize),
            "setinlined(true) and setoptimized(false) are incompatible")
 end
+function T.terrafunction:setcallingconv(v)
+    assert(self:isdefined(), "attempting to set the calling convention of an undefined function")
+    self.definition.callingconv = tostring(v)
+end
 function T.terrafunction:setnoreturn(v)
     assert(self:isdefined(), "attempting to set the noreturn state of an undefined function")
     self.definition.noreturn = not not v

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -1,0 +1,27 @@
+local arch = 'gfx908'
+local amd_target = terralib.newtarget {
+  Triple = 'amdgcn-amd-amdhsa',
+  CPU = arch,
+  FloatABIHard = true,
+}
+
+local wgx = terralib.intrinsic("llvm.amdgcn.workgroup.id.x",{} -> int32)
+local wix = terralib.intrinsic("llvm.amdgcn.workitem.id.x",{} -> int32)
+
+terra f(a : float, x : float, y : float)
+  return a * x + y
+end
+
+local workgroup_size = 256
+
+terra saxpy(num_elements : uint64, alpha : float,
+            x : &float, y : &float, z : &float)
+  var idx = wgx() * workgroup_size + wix()
+  if idx < num_elements then
+    z[idx] = z[idx] + alpha * x[idx] + y[idx]
+  end
+end
+saxpy:setcallingconv("amdgpu_kernel")
+
+local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy}, {}, amd_target)
+assert(string.match(ir, "define dso_local amdgpu_kernel void @saxpy"))

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -1,5 +1,6 @@
 if terralib.llvm_version < 90 then
   print("LLVM is too old, skipping AMD GPU test...")
+  return
 end
 
 local arch = 'gfx908'

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -1,3 +1,7 @@
+if terralib.llvm_version < 90 then
+  print("LLVM is too old, skipping AMD GPU test...")
+end
+
 local arch = 'gfx908'
 local amd_target = terralib.newtarget {
   Triple = 'amdgcn-amd-amdhsa',


### PR DESCRIPTION
Needed to be able to correctly generate AMD GPU kernels, among other things.