### PR TITLE
Move LLVM 13 tests to Docker to fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'macos-10.15']
-        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12', '13']
+        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12']
         cmake: ['0', '1']
         cuda: ['0', '1']
         static: ['0', '1']
@@ -170,13 +170,23 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04']
-        llvm: ['3.8', '6.0']
+        distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-21.10']
+        llvm: ['3.8', '6.0', '13']
         exclude:
           - distro: 'ubuntu-18.04'
             llvm: '3.8'
           - distro: 'ubuntu-20.04'
             llvm: '3.8'
+          - distro: 'ubuntu-21.10'
+            llvm: '3.8'
+          - distro: 'ubuntu-21.10'
+            llvm: '6.0'
+          - distro: 'ubuntu-16.04'
+            llvm: '13'
+          - distro: 'ubuntu-18.04'
+            llvm: '13'
+          - distro: 'ubuntu-20.04'
+            llvm: '13'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -9,7 +9,7 @@ ENV DEBIAN_FRONTEND noninteractive
 COPY . /terra
 
 RUN apt-get update -qq && \
-    apt-get install -qq build-essential cmake git llvm-$llvm-dev libclang-$llvm-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev && \
+    apt-get install -qq build-essential cmake git llvm-$llvm-dev libclang-$llvm-dev clang-$llvm libedit-dev libncurses5-dev zlib1g-dev libpfm4-dev && \
     cd /terra/build && \
     cmake -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
     make install -j4 && \

--- a/travis.sh
+++ b/travis.sh
@@ -25,10 +25,11 @@ if [[ -n $DOCKER_BUILD ]]; then
 fi
 
 if [[ $(uname) = Linux ]]; then
+  distro_name="$(lsb_release -cs)"
   sudo apt-get update -qq
   if [[ $LLVM_CONFIG = llvm-config-13 ]]; then
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-13 main"
+    sudo add-apt-repository -y "deb http://apt.llvm.org/${distro_name}/ llvm-toolchain-${distro_name}-13 main"
     for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-13-dev clang-13 libclang-13-dev libedit-dev libpfm4-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-13:/usr/share/llvm-13
@@ -37,7 +38,7 @@ if [[ $(uname) = Linux ]]; then
     fi
   elif [[ $LLVM_CONFIG = llvm-config-12 ]]; then
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-12 main"
+    sudo add-apt-repository -y "deb http://apt.llvm.org/${distro_name}/ llvm-toolchain-${distro_name}-12 main"
     for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-12-dev clang-12 libclang-12-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-12:/usr/share/llvm-12
@@ -46,7 +47,7 @@ if [[ $(uname) = Linux ]]; then
     fi
   elif [[ $LLVM_CONFIG = llvm-config-11 ]]; then
     wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-    sudo add-apt-repository -y "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-11 main"
+    sudo add-apt-repository -y "deb http://apt.llvm.org/${distro_name}/ llvm-toolchain-${distro_name}-11 main"
     for i in {1..5}; do sudo apt-get update -qq && break || sleep 15; done
     sudo apt-get install -y llvm-11-dev clang-11 libclang-11-dev libedit-dev
     export CMAKE_PREFIX_PATH=/usr/lib/llvm-11:/usr/share/llvm-11


### PR DESCRIPTION
As best I can tell, a packaging bug in the official LLVM 13.0.1 binaries broke the CI. Unfortunately the Apt mirror for LLVM does not provide old versions, so we can't downgrade. I am moving the LLVM 13 tests into Docker for the time being so that we can take advantage of LLVM 13 in the official Ubuntu package repository for Ubuntu 21.10.

Once Ubuntu 22.04 is released and made available via Github Actions, that will probably make it possible to move back. Alternatively, maybe this is the signal that I should be moving more tests into Docker....

Also includes some minor refactoring to make future Ubuntu upgrades easier.