### PR TITLE
Fix incorrect use of address space in aggregate parameters

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1054,7 +1054,7 @@ struct CCallingConv {
         return fn;
     }
 
-    PointerType *Ptr(Type *t) { return PointerType::getUnqual(t); }
+    PointerType *Ptr(Type *t, unsigned as = 0) { return PointerType::get(t, as); }
     Value *ConvertPrimitive(IRBuilder<> *B, Value *src, Type *dstType, bool issigned) {
         if (!dstType->isIntegerTy()) return src;
         if (dstType == Type::getInt1Ty(*CU->TT->ctx)) {
@@ -1087,7 +1087,8 @@ struct CCallingConv {
                     ++ai;
                     break;
                 case C_AGGREGATE_REG: {
-                    Value *dest = B->CreateBitCast(v, Ptr(p->cctype));
+                    unsigned as = v->getType()->getPointerAddressSpace();
+                    Value *dest = B->CreateBitCast(v, Ptr(p->cctype, as));
                     int N = p->GetNumberOfTypesInParamList();
                     for (int j = 0; j < N; j++) {
                         B->CreateStore(&*ai, CreateConstGEP2_32(B, dest, 0, j));

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1184,7 +1184,8 @@ struct CCallingConv {
             } else {  // C_AGGREGATE_REG
                 aggregate = CreateAlloca(B, info.returntype.type->type);
                 unsigned as = aggregate->getType()->getPointerAddressSpace();
-                Value *casted = B->CreateBitCast(aggregate, Ptr(info.returntype.cctype, as));
+                Value *casted =
+                        B->CreateBitCast(aggregate, Ptr(info.returntype.cctype, as));
                 if (info.returntype.GetNumberOfTypesInParamList() == 1)
                     casted = CreateConstGEP2_32(B, casted, 0, 0);
                 if (info.returntype.GetNumberOfTypesInParamList() > 0)

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -34,5 +34,10 @@ terra f()
 end
 f:setcallingconv("amdgpu_kernel")
 
-local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f}, {}, amd_target)
+-- Another pattern that requires being careful about the addrspace.
+terra g(x : i2)
+end
+g:setcallingconv("amdgpu_kernel")
+
+local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g}, {}, amd_target)
 assert(string.match(ir, "define dso_local amdgpu_kernel void @saxpy"))

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -28,26 +28,17 @@ struct i2 {
   x : int,
   y : int,
 }
-terra f()
-  -- Allocas use an address space in AMDGPU target, make sure that is respected.
-  var x = i2 {1, 1}
-end
-f:setcallingconv("amdgpu_kernel")
-
--- Another pattern that requires being careful about the addrspace.
-terra g(x : i2)
-end
-g:setcallingconv("amdgpu_kernel")
 
 terra sub_i2(a : i2, b : i2)
   return [i2]({ a.x - b.x, a.y - b.y })
 end
 
-terra h(y : i2)
-    var i = [i2]({0, 0})
-    var x = sub_i2(i, y)
+-- Allocas use an address space in AMDGPU target, make sure that is respected.
+terra f(y : i2)
+  var i = [i2]({0, 0})
+  var x = sub_i2(i, y)
 end
-h:setcallingconv("amdgpu_kernel")
+f:setcallingconv("amdgpu_kernel")
 
-local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g, h=h}, {}, amd_target)
+local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f}, {}, amd_target)
 assert(string.match(ir, "define dso_local amdgpu_kernel void @saxpy"))

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -39,5 +39,15 @@ terra g(x : i2)
 end
 g:setcallingconv("amdgpu_kernel")
 
-local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g}, {}, amd_target)
+terra sub_i2(a : i2, b : i2)
+  return [i2]({ a.x - b.x, a.y - b.y })
+end
+
+terra h(y : i2)
+    var i = [i2]({0, 0})
+    var x = sub_i2(i, y)
+end
+h:setcallingconv("amdgpu_kernel")
+
+local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g, h=h}, {}, amd_target)
 assert(string.match(ir, "define dso_local amdgpu_kernel void @saxpy"))


### PR DESCRIPTION
Fixing another pattern that requires the correct use of address spaces.