### PR TITLE
Fixes for AMDGPU calling convention

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -782,9 +782,20 @@ struct CCallingConv {
             this->type = type;
             this->cctype = cctype ? cctype : type->type;
         }
+        int GetNumberOfTypesInParamList(Type *type) {
+            StructType *st = dyn_cast<StructType>(type);
+            if (st) {
+                size_t total = 0;
+                for (auto elt_type : st->elements()) {
+                    total += GetNumberOfTypesInParamList(elt_type);
+                }
+                return total;
+            }
+            return 1;
+        }
         int GetNumberOfTypesInParamList() {
             if (C_AGGREGATE_REG == this->kind)
-                return cast<StructType>(this->cctype)->getNumElements();
+                return GetNumberOfTypesInParamList(this->cctype);
             return 1;
         }
     };
@@ -1075,6 +1086,19 @@ struct CCallingConv {
             return B->CreateIntCast(src, dstType, issigned);
         }
     }
+    void EmitEntryAggReg(IRBuilder<> *B, Value *dest, Type *arg_type, Function::arg_iterator &ai) {
+      StructType *st = dyn_cast<StructType>(arg_type);
+      if (st) {
+        int N = st->getNumElements();
+        for (int j = 0; j < N; j++) {
+          Type *elt_type = st->getElementType(j);
+          EmitEntryAggReg(B, CreateConstGEP2_32(B, dest, 0, j), elt_type, ai);
+        }
+      } else {
+        B->CreateStore(&*ai, dest);
+        ++ai;
+      }
+    }
     void EmitEntry(IRBuilder<> *B, Obj *ftype, Function *func,
                    std::vector<Value *> *variables) {
         Classification *info = ClassifyFunction(ftype);
@@ -1101,11 +1125,7 @@ struct CCallingConv {
                 case C_AGGREGATE_REG: {
                     unsigned as = v->getType()->getPointerAddressSpace();
                     Value *dest = B->CreateBitCast(v, Ptr(p->cctype, as));
-                    int N = p->GetNumberOfTypesInParamList();
-                    for (int j = 0; j < N; j++) {
-                        B->CreateStore(&*ai, CreateConstGEP2_32(B, dest, 0, j));
-                        ++ai;
-                    }
+                    EmitEntryAggReg(B, dest, p->cctype, ai);
                 } break;
             }
         }
@@ -1127,13 +1147,30 @@ struct CCallingConv {
             Value *dest = CreateAlloca(B, info->returntype.type->type);
             unsigned as = dest->getType()->getPointerAddressSpace();
             emitStoreAgg(B, info->returntype.type->type, result, dest);
-            Value *result = B->CreateBitCast(dest, Ptr(info->returntype.cctype, as));
-            if (info->returntype.GetNumberOfTypesInParamList() == 1)
-                result = CreateConstGEP2_32(B, result, 0, 0);
+            StructType *type = cast<StructType>(info->returntype.cctype);
+            Value *result = B->CreateBitCast(dest, Ptr(type, as));
+            if (info->returntype.GetNumberOfTypesInParamList() == 1) {
+                do {
+                    result = CreateConstGEP2_32(B, result, 0, 0);
+                } while (type = dyn_cast<StructType>(type->getElementType(0)));
+            }
             B->CreateRet(B->CreateLoad(result));
         } else {
             assert(!"unhandled return value");
         }
+    }
+
+    void EmitCallAggReg(IRBuilder<> *B, Value *value, Type *param_type, std::vector<Value *> &arguments) {
+      StructType *st = dyn_cast<StructType>(param_type);
+      if (st) {
+        int N = st->getNumElements();
+        for (int j = 0; j < N; j++) {
+          Type *elt_type = st->getElementType(j);
+          EmitCallAggReg(B, CreateConstGEP2_32(B, value, 0, j), elt_type, arguments);
+        }
+      } else {
+        arguments.push_back(B->CreateLoad(value));
+      }
     }
 
     Value *EmitCall(IRBuilder<> *B, Obj *ftype, Obj *paramtypes, Value *callee,
@@ -1165,11 +1202,7 @@ struct CCallingConv {
                     unsigned as = scratch->getType()->getPointerAddressSpace();
                     emitStoreAgg(B, a->type->type, actual, scratch);
                     Value *casted = B->CreateBitCast(scratch, Ptr(a->cctype, as));
-                    int N = a->GetNumberOfTypesInParamList();
-                    for (int j = 0; j < N; j++) {
-                        arguments.push_back(
-                                B->CreateLoad(CreateConstGEP2_32(B, casted, 0, j)));
-                    }
+                    EmitCallAggReg(B, casted, a->cctype, arguments);
                 } break;
             }
         }
@@ -1193,14 +1226,26 @@ struct CCallingConv {
             } else {  // C_AGGREGATE_REG
                 aggregate = CreateAlloca(B, info.returntype.type->type);
                 unsigned as = aggregate->getType()->getPointerAddressSpace();
-                Value *casted =
-                        B->CreateBitCast(aggregate, Ptr(info.returntype.cctype, as));
+                StructType *type = cast<StructType>(info.returntype.cctype);
+                Value *casted = B->CreateBitCast(aggregate, Ptr(type, as));
                 if (info.returntype.GetNumberOfTypesInParamList() == 1)
-                    casted = CreateConstGEP2_32(B, casted, 0, 0);
+                    do {
+                        casted = CreateConstGEP2_32(B, casted, 0, 0);
+                    } while (type = dyn_cast<StructType>(type->getElementType(0)));
                 if (info.returntype.GetNumberOfTypesInParamList() > 0)
                     B->CreateStore(call, casted);
             }
             return B->CreateLoad(aggregate);
+        }
+    }
+    void GatherArgumentsAggReg(Type *type, std::vector<Type *> &arguments) {
+        StructType *st = dyn_cast<StructType>(type);
+        if (st) {
+            for (auto elt_type : st->elements()) {
+                GatherArgumentsAggReg(elt_type, arguments);
+            }
+        } else {
+            arguments.push_back(type);
         }
     }
     FunctionType *CreateFunctionType(Classification *info, bool isvararg) {
@@ -1213,8 +1258,12 @@ struct CCallingConv {
                     case 0:
                         rt = Type::getVoidTy(*CU->TT->ctx);
                         break;
-                    case 1:
-                        rt = cast<StructType>(info->returntype.cctype)->getElementType(0);
+                    case 1: {
+                        StructType *type = cast<StructType>(info->returntype.cctype);
+                        do {
+                            rt = type;
+                        } while (type = dyn_cast<StructType>(type->getElementType(0)));
+                    }
                         break;
                     default:
                         rt = info->returntype.cctype;
@@ -1240,11 +1289,7 @@ struct CCallingConv {
                     arguments.push_back(Ptr(a->type->type));
                     break;
                 case C_AGGREGATE_REG: {
-                    int N = a->GetNumberOfTypesInParamList();
-                    for (int j = 0; j < N; j++) {
-                        arguments.push_back(
-                                cast<StructType>(a->cctype)->getElementType(j));
-                    }
+                    GatherArgumentsAggReg(a->cctype, arguments);
                 } break;
             }
         }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -773,9 +773,9 @@ struct CCallingConv {
         ArgumentKind kind;
         TType *type;   // orignal type for the object
         Type *cctype;  // if type == C_AGGREGATE_REG, this is a struct that holds a list
-                       // of the values that goes into the registers if type ==
-                       // CC_PRIMITIVE, this is the struct that this type appear in the
-                       // argument list and the type should be coerced to
+                       // of the values that goes into the registers
+                       // if type == CC_PRIMITIVE, this is the struct that this type
+                       // appear in the argument list and the type should be coerced to
         Argument() {}
         Argument(ArgumentKind kind, TType *type, Type *cctype = NULL) {
             this->kind = kind;
@@ -1005,7 +1005,7 @@ struct CCallingConv {
         if ((t1->isStructTy() || (t1->isArrayTy())) && l) {
             // create bitcasts of src and dest address
             Value *addr_src = l->getOperand(0);
-            unsigned as_src = addr_dst->getType()->getPointerAddressSpace();
+            unsigned as_src = addr_src->getType()->getPointerAddressSpace();
             Type *t_src = Type::getInt8PtrTy(*CU->TT->ctx, as_src);
             unsigned as_dst = addr_dst->getType()->getPointerAddressSpace();
             Type *t_dst = Type::getInt8PtrTy(*CU->TT->ctx, as_dst);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1152,7 +1152,7 @@ struct CCallingConv {
             if (info->returntype.GetNumberOfTypesInParamList() == 1) {
                 do {
                     result = CreateConstGEP2_32(B, result, 0, 0);
-                } while (type = dyn_cast<StructType>(type->getElementType(0)));
+                } while ((type = dyn_cast<StructType>(type->getElementType(0))));
             }
             B->CreateRet(B->CreateLoad(result));
         } else {
@@ -1231,7 +1231,7 @@ struct CCallingConv {
                 if (info.returntype.GetNumberOfTypesInParamList() == 1)
                     do {
                         casted = CreateConstGEP2_32(B, casted, 0, 0);
-                    } while (type = dyn_cast<StructType>(type->getElementType(0)));
+                    } while ((type = dyn_cast<StructType>(type->getElementType(0))));
                 if (info.returntype.GetNumberOfTypesInParamList() > 0)
                     B->CreateStore(call, casted);
             }
@@ -1261,8 +1261,8 @@ struct CCallingConv {
                     case 1: {
                         StructType *type = cast<StructType>(info->returntype.cctype);
                         do {
-                            rt = type;
-                        } while (type = dyn_cast<StructType>(type->getElementType(0)));
+                            rt = type->getElementType(0);
+                        } while ((type = dyn_cast<StructType>(rt)));
                     }
                         break;
                     default:

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -24,6 +24,18 @@ terra saxpy(num_elements : uint64, alpha : float,
 end
 saxpy:setcallingconv("amdgpu_kernel")
 
+-- Run some tests to make sure AMDGPU codegen is working. In particular:
+--  * AMDGPU uses a non-zero address space for allocas
+--  * AMDGPU requires structs to be passed by registers rather than the stack.
+
+struct i1 {
+  x : int32,
+}
+
+terra sub_i1(a : i1, b : i1)
+  return [i1]({ a.x - b.x })
+end
+
 struct i2 {
   x : int32,
   y : int32,
@@ -33,13 +45,8 @@ terra sub_i2(a : i2, b : i2)
   return [i2]({ a.x - b.x, a.y - b.y })
 end
 
--- Allocas use an address space in AMDGPU target, make sure that is respected.
-terra f(y : i2)
-  var i = [i2]({0, 0})
-  var x = sub_i2(i, y)
-end
-f:setcallingconv("amdgpu_kernel")
-
+-- Make sure this struct is large enough to trip over size limits if
+-- we don't do the right thing.
 struct i3 {
   x : int64,
   y : int64,
@@ -50,12 +57,38 @@ terra sub_i3(a : i3, b : i3)
   return [i3]({ a.x - b.x, a.y - b.y, a.z - b.z })
 end
 
--- Same with a struct large enough to force passing by value.
-terra g(y : i3)
-  var i = [i3]({0, 0, 0})
-  var x = sub_i3(i, y)
+-- Nested structs.
+struct i3p {
+  p : i3,
+}
+
+terra sub_i3p(a : i3p, b : i3p)
+  return [i3p]({ sub_i3(a.p, b.p) })
+end
+
+terra f(y : i1)
+  var i = [i1]({0})
+  var x = sub_i1(i, y)
+end
+f:setcallingconv("amdgpu_kernel")
+
+terra g(y : i2)
+  var i = [i2]({0, 0})
+  var x = sub_i2(i, y)
 end
 g:setcallingconv("amdgpu_kernel")
 
-local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g}, {}, amd_target)
+terra h(y : i3)
+  var i = [i3]({0, 0, 0})
+  var x = sub_i3(i, y)
+end
+h:setcallingconv("amdgpu_kernel")
+
+terra k(y : i3p)
+  var i = [i3p]({ [i3]({ 0, 0, 0}) })
+  var x = sub_i3p(i, y)
+end
+k:setcallingconv("amdgpu_kernel")
+
+local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g, h=h, k=k}, {}, amd_target)
 assert(string.match(ir, "define dso_local amdgpu_kernel void @saxpy"))


### PR DESCRIPTION
AMDGPU backend requires the use of `C_AGGREGATE_REG` (i.e., exploding a struct into its component fields) calling convention rather than `C_AGGREGATE_MEM` (i.e., using `byval` and `sret` to pass the struct on the stack). This change checks the target machine and generates the correct code in the AMDGPU case.

Arguably, this was intended to be done within `CCallingConv` itself, but that would be a larger change and would also involve potentially a lot of code duplication. I do not attempt to do that in this change.

I also modified `C_AGGREGATE_REG` to correctly handle nested structs, which otherwise are not properly exploded. (The previous code unwrapped only one level of the struct.)

Contains one other typo fix for aggregate stores to make sure we use the right address space.