### PR TITLE
Release configuration updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -169,7 +169,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
-        llvm: ['3.8', '6.0', '13']
+        llvm: ['3.8', '6.0', '12']
         exclude:
           - distro: 'ubuntu-18.04'
             llvm: '3.8'
@@ -180,11 +180,11 @@ jobs:
           - distro: 'ubuntu-22.04'
             llvm: '6.0'
           - distro: 'ubuntu-16.04'
-            llvm: '13'
+            llvm: '12'
           - distro: 'ubuntu-18.04'
-            llvm: '13'
+            llvm: '12'
           - distro: 'ubuntu-20.04'
-            llvm: '13'
+            llvm: '12'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,13 +16,17 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'macos-10.15']
-        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12']
+        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12', '13']
         cmake: ['0', '1']
         cuda: ['0', '1']
         static: ['0', '1']
         slib: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
+          # Linux: exclude LLVM 13
+          - os: 'ubuntu-18.04'
+            llvm: '13'
+
           # macOS: exclude LLVM 5.0, 8-13 make, cuda/no-static/no-slib
           - os: 'macos-10.15'
             llvm: '5.0'
@@ -164,16 +168,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-21.10']
+        distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
         llvm: ['3.8', '6.0', '13']
         exclude:
           - distro: 'ubuntu-18.04'
             llvm: '3.8'
           - distro: 'ubuntu-20.04'
             llvm: '3.8'
-          - distro: 'ubuntu-21.10'
+          - distro: 'ubuntu-22.04'
             llvm: '3.8'
-          - distro: 'ubuntu-21.10'
+          - distro: 'ubuntu-22.04'
             llvm: '6.0'
           - distro: 'ubuntu-16.04'
             llvm: '13'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,8 +162,8 @@ jobs:
         with:
           name: terra-${{ matrix.os }}-llvm-${{ matrix.llvm }}
           path: |
-            *.tar.xz
-            *.7z
+            terra-*.tar.xz
+            terra-*.7z
   docker:
     name: Docker
     runs-on: ubuntu-latest
@@ -202,8 +202,8 @@ jobs:
         with:
           name: docker-ubuntu-18.04-llvm-13.0
           path: |
-            *.tar.xz
-            *.7z
+            terra-*.tar.xz
+            terra-*.7z
   nix:
     name: Nix Build (nixpkgs-${{ matrix.nixpkgs }}, enableCUDA=${{ matrix.cuda }})
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,7 +162,8 @@ jobs:
         with:
           name: terra-${{ matrix.os }}-llvm-${{ matrix.llvm }}
           path: |
-            *.zip
+            *.tar.xz
+            *.7z
   docker:
     name: Docker
     runs-on: ubuntu-latest
@@ -201,7 +202,8 @@ jobs:
         with:
           name: docker-ubuntu-18.04-llvm-13.0
           path: |
-            *.zip
+            *.tar.xz
+            *.7z
   nix:
     name: Nix Build (nixpkgs-${{ matrix.nixpkgs }}, enableCUDA=${{ matrix.cuda }})
     runs-on: ubuntu-latest

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -6,6 +6,7 @@ ARG llvm=6.0
 ARG threads=4
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV CI 1 # skip CUDA tests
 
 COPY . /terra
 

--- a/docker/Dockerfile.ubuntu-prebuilt
+++ b/docker/Dockerfile.ubuntu-prebuilt
@@ -6,6 +6,7 @@ ARG llvm=6.0
 ARG threads=4
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV CI 1 # skip CUDA tests
 
 COPY . /terra
 

--- a/docker/Dockerfile.ubuntu-prebuilt
+++ b/docker/Dockerfile.ubuntu-prebuilt
@@ -15,6 +15,7 @@ RUN apt-get update -qq && \
     tar xf clang+llvm-$llvm-x86_64-linux-gnu.tar.xz && \
     mv clang+llvm-$llvm-x86_64-linux-gnu /llvm && \
     rm clang+llvm-$llvm-x86_64-linux-gnu.tar.xz && \
+    /terra/docker/install_cuda.sh && \
     cd /terra/build && \
     cmake -DCMAKE_PREFIX_PATH=/llvm/install -DCMAKE_INSTALL_PREFIX=/terra_install .. && \
     make install -j$threads && \

--- a/docker/Dockerfile.ubuntu-source
+++ b/docker/Dockerfile.ubuntu-source
@@ -6,6 +6,7 @@ ARG llvm=6.0
 ARG threads=4
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV CI 1 # skip CUDA tests
 
 COPY . /terra
 

--- a/docker/Dockerfile.ubuntu-source-test
+++ b/docker/Dockerfile.ubuntu-source-test
@@ -3,6 +3,7 @@ ARG release=16.04
 FROM ubuntu:$release
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV CI 1 # skip CUDA tests
 
 COPY . /terra_install
 

--- a/docker/Dockerfile.ubuntu-test
+++ b/docker/Dockerfile.ubuntu-test
@@ -3,6 +3,7 @@ ARG release=16.04
 FROM ubuntu:$release
 
 ENV DEBIAN_FRONTEND noninteractive
+ENV CI 1 # skip CUDA tests
 
 COPY . /terra_install
 

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -14,11 +14,7 @@ tmp=$(docker create terralang/terra:$distro-$release)
 docker cp $tmp:/terra_install .
 docker rm $tmp
 
-if command -v zip; then
-    RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/`-`uname -m`-`git rev-parse --short HEAD`
-    mv terra_install $RELEASE_NAME
-    tar cfJv $RELEASE_NAME.tar.xz $RELEASE_NAME
-    mv $RELEASE_NAME terra_install
-else
-    echo "The zip program is not available. Can't make a release."
-fi
+RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/`-`uname -m`-`git rev-parse --short HEAD`
+mv terra_install $RELEASE_NAME
+tar cfJv $RELEASE_NAME.tar.xz $RELEASE_NAME
+mv $RELEASE_NAME terra_install

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -17,7 +17,7 @@ docker rm $tmp
 if command -v zip; then
     RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/`-`uname -m`-`git rev-parse --short HEAD`
     mv terra_install $RELEASE_NAME
-    zip -q -r $RELEASE_NAME.zip $RELEASE_NAME
+    tar cfJv $RELEASE_NAME.tar.xz $RELEASE_NAME
     mv $RELEASE_NAME terra_install
 else
     echo "The zip program is not available. Can't make a release."

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -e
+set -x
+
+apt-get update -qq
+apt-get install -qq software-properties-common
+wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+apt-get update -qq
+apt-get install -qq cuda-toolkit-11.6

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -8,7 +8,7 @@ sudo_command="$1"
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
-mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+$sudo_command mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
 $sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
 $sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
 $sudo_command apt-get update -qq

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -3,11 +3,13 @@
 set -e
 set -x
 
-apt-get update -qq
-apt-get install -qq software-properties-common
+sudo_command="$1"
+
+$sudo_command apt-get update -qq
+$sudo_command apt-get install -qq software-properties-common
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
 mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
-add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
-apt-get update -qq
-apt-get install -qq cuda-toolkit-11.6
+$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+$sudo_command apt-get update -qq
+$sudo_command apt-get install -qq cuda-toolkit-11.6

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -12,4 +12,4 @@ $sudo_command mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-
 $sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
 $sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
 $sudo_command apt-get update -qq
-$sudo_command apt-get install -qq cuda-toolkit-11.6
+$sudo_command apt-get install -qq cuda-compiler-11.6

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -119,11 +119,6 @@ On macOS with Homebrew, the following should be sufficient:
 brew install cmake llvm@6
 ```
 
-Note that in Ubuntu, the LLVM packages for versions < 6 are broken in
-Ubuntu 16.04 and older. Please either upgrade to LLVM 6 or Ubuntu
-18.04, or build LLVM from source, or else use GNU Make on these
-systems (see below).
-
 Terra also supports an older build system based on GNU Make (for Linux
 and macOS only). This build system is deprecated, and in the vast
 majority of circumstances CMake is both preferred and substantially
@@ -131,7 +126,7 @@ more flexible.
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **6.0**. The following versions are also supported:
+The current recommended version of LLVM is **13.0**. The following versions are also supported:
 
 | Version | CI Coverage | CUDA | Notes |
 | ------- | ----------- | ---- | ----- |
@@ -163,14 +158,14 @@ the following recipe has been known to work with Terra. The same
 basic procedure should work for all LLVM versions >= 3.8.
 
 ```
-wget https://releases.llvm.org/9.0.0/llvm-9.0.0.src.tar.xz
-wget https://releases.llvm.org/9.0.0/cfe-9.0.0.src.tar.xz
-tar xf llvm-9.0.0.src.tar.xz
-tar xf cfe-9.0.0.src.tar.xz
-mv cfe-9.0.0.src llvm-9.0.0.src/tools/clang
+wget https://releases.llvm.org/13.0.0/llvm-13.0.0.src.tar.xz
+wget https://releases.llvm.org/13.0.0/cfe-13.0.0.src.tar.xz
+tar xf llvm-13.0.0.src.tar.xz
+tar xf cfe-13.0.0.src.tar.xz
+mv cfe-13.0.0.src llvm-13.0.0.src/tools/clang
 mkdir build install
 cd build
-cmake ../llvm-9.0.0.src -DCMAKE_INSTALL_PREFIX=$PWD/../install -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_LIBEDIT=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_ASSERTIONS=OFF
+cmake ../llvm-13.0.0.src -DCMAKE_INSTALL_PREFIX=$PWD/../install -DCMAKE_BUILD_TYPE=Release -DLLVM_ENABLE_TERMINFO=OFF -DLLVM_ENABLE_LIBEDIT=OFF -DLLVM_ENABLE_ZLIB=OFF -DLLVM_ENABLE_ASSERTIONS=OFF
 make install -j4 # tune this for how many cores you have
 ```
 

--- a/travis.sh
+++ b/travis.sh
@@ -78,7 +78,7 @@ if [[ $(uname) = Linux ]]; then
   fi
 
   if [[ $USE_CUDA -eq 1 ]]; then
-    ./docker/install_cuda.sh
+    ./docker/install_cuda.sh sudo
   fi
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -78,11 +78,7 @@ if [[ $(uname) = Linux ]]; then
   fi
 
   if [[ $USE_CUDA -eq 1 ]]; then
-    wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/cuda-repo-ubuntu1604_9.2.148-1_amd64.deb
-    sudo dpkg -i cuda-repo-ubuntu1604_9.2.148-1_amd64.deb
-    sudo apt-key adv --fetch-keys http://developer.download.nvidia.com/compute/cuda/repos/ubuntu1604/x86_64/7fa2af80.pub
-    sudo apt-get update -qq
-    sudo apt-get install -qq cuda-toolkit-9.2
+    ./docker/install_cuda.sh
   fi
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -152,19 +152,6 @@ if [[ $(uname) = Darwin ]]; then
     exit 1
   fi
 
-  if [[ $USE_CUDA -eq 1 ]]; then
-    curl -L -o cuda.dmg https://developer.nvidia.com/compute/cuda/9.2/Prod2/local_installers/cuda_9.2.148_mac
-    echo "defb095aa002301f01b2f41312c9b1630328847800baa1772fe2bbb811d5fa9f  cuda.dmg" | shasum -c -a 256
-    hdiutil attach cuda.dmg
-    # This is probably the "correct" way to do it, but it times out on Travis.
-    # /Volumes/CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/MacOS/CUDAMacOSXInstaller --accept-eula --silent --no-window --install-package=cuda-toolkit
-    # There is a bug in GNU Tar 1.31 which causes a crash; stick to 1.30 for now.
-    brew tap elliottslaughter/tap
-    brew install gnu-tar@1.30
-    sudo gtar xf /Volumes/CUDAMacOSXInstaller/CUDAMacOSXInstaller.app/Contents/Resources/payload/cuda_mac_installer_tk.tar.gz -C / --no-overwrite-dir --no-same-owner
-    hdiutil detach /Volumes/CUDAMacOSXInstaller
-  fi
-
   # workaround for https://github.com/terralang/terra/issues/365
   if [[ ! -e /usr/include ]]; then
     export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
@@ -214,11 +201,11 @@ if [[ $USE_CMAKE -eq 1 ]]; then
       popd
   fi
 
-  # Only deploy CMake builds, and only with LLVM 9.
-  if [[ $LLVM_CONFIG = llvm-config-9 && $SLIB_INCLUDE_LLVM -eq 1 && ( $USE_CUDA -eq 1 || $(uname) == Darwin ) && $TERRA_LUA = luajit ]]; then
+  # Only deploy CMake builds, and only with LLVM 13.
+  if [[ $LLVM_CONFIG = llvm-config-13 && $SLIB_INCLUDE_LLVM -eq 1 && $(uname) == Darwin && $TERRA_LUA = luajit ]]; then
     RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/`-`uname -m`-`git rev-parse --short HEAD`
     mv install $RELEASE_NAME
-    zip -q -r $RELEASE_NAME.zip $RELEASE_NAME
+    tar cfJv $RELEASE_NAME.tar.xz $RELEASE_NAME
     mv $RELEASE_NAME install
   fi
 else


### PR DESCRIPTION
This PR includes (or will include) a number of changes:

 - [x] Update macOS build to LLVM 13 (and release that build).
 - [x] Remove macOS build with CUDA. [1]
 - [x] Release only Linux binaries built with Docker. Do not release Linux binaries built directly on GitHub Actions (without Docker).
 - [x] Update Docker build to include CUDA, and update that CUDA to a reasonably recent release (e.g., 11.x).
 - [x] Formally recommend LLVM 13 as the best version in the README.


[1]: There is no recent Mac hardware that includes NVIDIA GPUs, and based on Apple's direction I don't believe it's likely to come back any time soon. We already removed it from CI a while ago, and the CUDA process was always clunky, so maintainin the dead code just doesn't seem worth it.