### PR TITLE
Initialize CUDA target lazily

### DIFF
--- a/src/cudalib.lua
+++ b/src/cudalib.lua
@@ -29,7 +29,7 @@ terralib.CUDAParams.entries = { { "gridDimX", uint },
 function cudalib.toptx(module,dumpmodule,version,profile)
     dumpmodule,version = not not dumpmodule,assert(tonumber(version))
     profile = profile or {fastmath=false}
-    local cu = terralib.newcompilationunit(terra.cudatarget, false, profile) -- TODO: add nvptx target options here
+    local cu = terralib.newcompilationunit(terra.getcudatarget(), false, profile) -- TODO: add nvptx target options here
     local annotations = terra.newlist{} -- list of annotations { functionname, annotationname, annotationvalue } to be tagged
     local function addkernel(k,fn)
         fn:setinlined(true)

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -4239,8 +4239,12 @@ if terra.cudalibpaths and terra.cudahome then
 	end
 end                       
 
-if terra.cudahome and terra.toptximpl then
-  terra.cudatarget = terra.newtarget {Triple = 'nvptx64-nvidia-cuda', FloatABIHard = true}
+local cudatarget
+function terra.getcudatarget()
+    if cudatarget == nil then
+        cudatarget = terra.newtarget {Triple = 'nvptx64-nvidia-cuda', FloatABIHard = true}
+    end
+    return cudatarget
 end
 
 

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -4239,7 +4239,7 @@ if terra.cudalibpaths and terra.cudahome then
 	end
 end                       
 
-if terra.cudahome then
+if terra.cudahome and rawget(package.loaded, "cudalib") ~= nil then
   terra.cudatarget = terra.newtarget {Triple = 'nvptx64-nvidia-cuda', FloatABIHard = true}
 end
 

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -4239,7 +4239,7 @@ if terra.cudalibpaths and terra.cudahome then
 	end
 end                       
 
-if terra.cudahome and rawget(package.loaded, "cudalib") ~= nil then
+if terra.cudahome and terra.toptximpl then
   terra.cudatarget = terra.newtarget {Triple = 'nvptx64-nvidia-cuda', FloatABIHard = true}
 end
 


### PR DESCRIPTION
This is to avoid dependency on LLVM NVPTX backend when it's not needed (when CUDA code generation is not enabled/used).

Fixes #446.