### PR TITLE
Upgrade to the newer split packages in NixOS unstable

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -7,7 +7,12 @@ let
 
   llvmPackages = pkgs.llvmPackages_10;
   stdenv = llvmPackages.stdenv;
-  cuda = if cudaPackages ? cudatoolkit_11 then cudaPackages.cudatoolkit_11 else pkgs.cudatoolkit;
+  cuda = if cudaPackages ? cudatoolkit_11 then [
+           cudaPackages.cudatoolkit_11
+         ] else [
+           cudaPackages.cuda_nvcc
+           cudaPackages.cuda_cudart
+         ];
 
   luajitRev = "9143e86498436892cb4316550be4d45b68a61224";
   luajitBase = "LuaJIT-${luajitRev}";
@@ -43,7 +48,7 @@ in stdenv.mkDerivation rec {
   src = ./.;
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmMerged ncurses libxml2 ] ++ lib.optional enableCUDA cuda;
+  buildInputs = [ llvmMerged ncurses libxml2 ] ++ lib.optionals enableCUDA cuda;
 
   cmakeFlags = [
     "-DHAS_TERRA_VERSION=0"


### PR DESCRIPTION
As described in [this thread](https://discourse.nixos.org/t/best-practice-for-referencing-cudatoolkit/18710), NixOS unstable is moving toward splitting the CUDA packages up into multiple pieces. This updates our Nix derivation so that hopefully we stay away from the breakage as the deprecate the old way of doing things.