### PR TITLE
Fix address of on targets with a non-generic default addrspace

### DIFF
--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -9,7 +9,7 @@ $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common
 wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
 $sudo_command mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/7fa2af80.pub
+$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
 $sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq cuda-compiler-11.6

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1816,8 +1816,13 @@ struct FunctionEmitter {
         return a;
     }
 
-    Value *emitAddressOf(Obj *exp) {
+    Value *emitAddressOf(Obj *exp, Obj *as_type=NULL) {
         Value *v = emitExp(exp, false);
+        if (as_type != NULL) {
+          Type *t = typeOfValue(as_type)->type;
+          if (t->getPointerAddressSpace() != v->getType()->getPointerAddressSpace())
+            v = B->CreateAddrSpaceCast(v, t);
+        }
         if (exp->boolean("lvalue")) return v;
         Value *addr = CreateAlloca(B, typeOfValue(exp)->type);
         B->CreateStore(v, addr);
@@ -1826,7 +1831,7 @@ struct FunctionEmitter {
 
     Value *emitUnary(Obj *exp, Obj *ao) {
         T_Kind kind = exp->kind("operator");
-        if (T_addressof == kind) return emitAddressOf(ao);
+        if (T_addressof == kind) return emitAddressOf(ao, exp);
 
         TType *t = typeOfValue(exp);
         Type *baseT = getPrimitiveType(t);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2678,12 +2678,11 @@ struct FunctionEmitter {
                 return a;
             } break;
             case T_cmpxchg: {
-                Obj addr, cmpvalue, newvalue, attr, typ;
+                Obj addr, cmpvalue, newvalue, attr;
                 exp->obj("address", &addr);
                 exp->obj("cmp", &cmpvalue);
                 exp->obj("new", &newvalue);
                 exp->obj("attrs", &attr);
-                exp->obj("type", &typ);
                 Value *addrexp = emitExp(&addr);
                 Value *cmpexp = emitExp(&cmpvalue);
                 Value *newexp = emitExp(&newvalue);
@@ -2735,7 +2734,7 @@ struct FunctionEmitter {
                 Value *a_success = B->CreateExtractValue(a, ArrayRef<unsigned>(1));
                 Value *a_success_i8 = B->CreateZExt(a_success, B->getInt8Ty());
                 Type *elt_types[2] = {a_result->getType(), B->getInt8Ty()};
-                Type *result_type = getType(&typ)->type;
+                Type *result_type = typeOfValue(exp)->type;
                 Value *result = UndefValue::get(result_type);
                 result = B->CreateInsertValue(result, a_result, ArrayRef<unsigned>(0));
                 result =

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1816,12 +1816,12 @@ struct FunctionEmitter {
         return a;
     }
 
-    Value *emitAddressOf(Obj *exp, Obj *as_type=NULL) {
+    Value *emitAddressOf(Obj *exp, Obj *as_type = NULL) {
         Value *v = emitExp(exp, false);
         if (as_type != NULL) {
-          Type *t = typeOfValue(as_type)->type;
-          if (t->getPointerAddressSpace() != v->getType()->getPointerAddressSpace())
-            v = B->CreateAddrSpaceCast(v, t);
+            Type *t = typeOfValue(as_type)->type;
+            if (t->getPointerAddressSpace() != v->getType()->getPointerAddressSpace())
+                v = B->CreateAddrSpaceCast(v, t);
         }
         if (exp->boolean("lvalue")) return v;
         Value *addr = CreateAlloca(B, typeOfValue(exp)->type);

--- a/tests/amdgpu_kernel.t
+++ b/tests/amdgpu_kernel.t
@@ -90,5 +90,14 @@ terra k(y : i3p)
 end
 k:setcallingconv("amdgpu_kernel")
 
-local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g, h=h, k=k}, {}, amd_target)
+-- Address of stack variable.
+terra m(z : &int)
+  var x = 0
+  var y = &x
+  @y = 123
+  z[0] = x
+end
+m:setcallingconv("amdgpu_kernel")
+
+local ir = terralib.saveobj(nil, "llvmir", {saxpy=saxpy, f=f, g=g, h=h, k=k, m=m}, {}, amd_target)
 assert(string.match(ir, "define dso_local amdgpu_kernel void @saxpy"))


### PR DESCRIPTION
On targets like AMDGPU where stack variables have a default address space, we need to be careful that the address of operator returns a pointer of the expected type (rather than blindly passing back the pointer it gets as the address).

This means that a stack variable `x` in AMDGPU will live in address space `5`, but when we do `&x` we return a pointer with address space `0` (i.e., a generic pointer). This requires an `addrspacecast` in the Terra backend.

One might wonder whether it would be better to make `&x` return `terralib.types.pointer(int, 5)` (i.e., pointer to addrspace `5`), but if we did this Terra functions would become target-specific. It would be impossible to even type check a function without having the target defined. So I think the only sensible approach is to make `&` return the generic addrspace and then cast it in the backend.

If it really becomes a problem down the road we may need to make a `terralib.addressof(x, 5)` operator to allow the user to specify the address space the pointer should be placed into.