### PR TITLE
Add check that geninternalizedfiles.lua finds at least one file

### DIFF
--- a/src/geninternalizedfiles.lua
+++ b/src/geninternalizedfiles.lua
@@ -14,6 +14,13 @@ for i = 2,#arg,2 do
         end
     end
 end
+-- Hack: we can't get the actual return code of the above command
+-- without LUAJIT_ENABLE_LUA52COMPAT (which might break
+-- compatibility), so we have to make do with checking that we got
+-- non-zero entries in our list of files.
+if #listoffiles == 0 then
+    assert(false, "unable to find any files to include")
+end
 
 local ContentTemplate = [[
 static const uint8_t headerfile_%d[] = { %s 0x0};


### PR DESCRIPTION
This is a workaround for the inability to check the return code of `io.popen` without Lua 5.2 compat being enabled (which I'm currently not willing to turn on, because it's a potential compatibility hazard).

If `find` (or its Windows equivalent) isn't present on the system, we'll get a list with zero header files in it; rather than generate un-parseable code, error out in `geninternalizedfiles.lua` so that we see the error close to the point where it occurs.