### PR TITLE
Fix CUDA: no longer need explicit addrspace casts

### DIFF
--- a/src/cudalib.lua
+++ b/src/cudalib.lua
@@ -366,11 +366,11 @@ end
 
 function cudalib.sharedmemory(typ,N)
     local gv = terralib.global(typ[N],nil,nil,N == 0,false,3)
-    return `[&typ](cudalib.nvvm_ptr_shared_to_gen_p0i8_p3i8([terralib.types.pointer(typ,3)](&gv[0])))
+    return `(&gv[0])
 end
 local constant = {
     __toterraexpression = function(self)
-        return `[&self.type](cudalib.nvvm_ptr_constant_to_gen_p0i8_p4i8([terralib.types.pointer(self.type,4)](&[self.global][0])))
+        return `(&[self.global][0])
     end
 }
 function cudalib.isconstant(c)


### PR DESCRIPTION
This is a follow-on to #547 which fixes a long-standing hack in the CUDA backend which is no longer necessary.

It used to be that an expression like `&gv` would incorrectly return a type of `terralib.types.pointer(T, 0)` if `T` was the type of `gv`, even if `gv` was located in a non-generic address space. This happens in CUDA where shared memory and constants are both located in non-generic address spaces. So then we'd get an LLVM expression of type `terralib.types.pointer(T, 3)` but Terra thought the type was `terralib.types.pointer(T, 0)`.

It looks like the old `cudalib.lua` just papered over the top of this by casting the address space back (a no-op in LLVM, but needed for Terra to understand the correct type), then using NVVM intrinsics to cast it away again (followed by another Terra cast). This is all unnecessary now because `&` actually understands the address space of both the argument and result types, and can cast as desired using LLVM's built-in `addrspacecast` instruction.

I think that's the only sane way to do it because in cases like AMD GPU, all stack variables have a non-generic address space by default and you can't even know this until you get to the point of lowering the function to LLVM.

Passes all Terra and Regent tests with LLVM 11 and CUDA 11.1.