### PR TITLE
Fix for use of C structs in different target from the defining one

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -652,13 +652,18 @@ class Types {
             size_t target_id = typ->number("llvm_definingtarget");
             TerraTarget *TT = T->targets[target_id];
             assert(TT);
-            Function *df = TT->external->getFunction(name);
-            assert(df);
-            int argpos = typ->number("llvm_argumentposition");
-            StructType *st = cast<StructType>(
-                    df->getFunctionType()->getParamType(argpos)->getPointerElementType());
-            assert(st);
-            return st;
+            // Important: only use the externally defined type if is was
+            // defined in the current target
+            if (TT == CU->TT) {
+                Function *df = TT->external->getFunction(name);
+                assert(df);
+                int argpos = typ->number("llvm_argumentposition");
+                StructType *st = cast<StructType>(df->getFunctionType()
+                                                          ->getParamType(argpos)
+                                                          ->getPointerElementType());
+                assert(st);
+                return st;
+            }
         }
         std::string name = typ->asstring("name");
         bool isreserved = beginsWith(name, "struct.") || beginsWith(name, "union.");

--- a/tests/amdgpu_struct.t
+++ b/tests/amdgpu_struct.t
@@ -1,0 +1,36 @@
+if terralib.llvm_version < 90 then
+  print("LLVM is too old, skipping AMD GPU test...")
+  return
+end
+
+-- This tests a bug that occurred when using C structs imported from a
+-- header file. The structs were associated with a certain target, and
+-- if used from a different target could cause issues.
+
+local c = terralib.includecstring [[
+typedef struct t {
+  int x;
+  int y;
+} t;
+]]
+
+terra f()
+  var s : c.t
+  s.x = 123
+  s.y = 456
+  return s.x + s.y
+end
+
+-- Works on CPU.
+print(f())
+assert(f() == 579)
+
+local arch = 'gfx908'
+local amd_target = terralib.newtarget {
+  Triple = 'amdgcn-amd-amdhsa',
+  CPU = arch,
+  FloatABIHard = true,
+}
+
+-- Make sure it also works on AMD GPU.
+print(terralib.saveobj(nil, "llvmir", {f=f}, nil, amd_target))


### PR DESCRIPTION
This is a problem that shows up in the AMD GPU backend, but I think it may also fix a related problem in CUDA (and other targets).

Structs imported via `terralib.includec` track the defining target/function, and use this to reconstitute the correct type when used later. This is not correct when generating code for a different target. So we should really only reuse the struct when the target matches.