### PR TITLE
Upgrade to a newer set of binaries that fix Windows build

### DIFF
--- a/travis.sh
+++ b/travis.sh
@@ -96,11 +96,11 @@ if [[ $(uname) = Darwin ]]; then
     ln -s clang+llvm-12.0.1-x86_64-apple-darwin/bin/clang clang-12
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-12.0.1-x86_64-apple-darwin
   elif [[ $LLVM_CONFIG = llvm-config-11 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.0.1/clang+llvm-11.0.1-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-11.0.1-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-11.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-11
-    ln -s clang+llvm-11.0.1-x86_64-apple-darwin/bin/clang clang-11
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.0.1-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-apple-darwin.tar.xz
+    tar xf clang+llvm-11.1.0-x86_64-apple-darwin.tar.xz
+    ln -s clang+llvm-11.1.0-x86_64-apple-darwin/bin/llvm-config llvm-config-11
+    ln -s clang+llvm-11.1.0-x86_64-apple-darwin/bin/clang clang-11
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-x86_64-apple-darwin
   elif [[ $LLVM_CONFIG = llvm-config-10 ]]; then
     curl -L -O https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz
     tar xf clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz
@@ -158,9 +158,9 @@ fi
 
 if [[ $(uname) = MINGW* ]]; then
   if [[ $LLVM_CONFIG = llvm-config-11 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.0.1/clang+llvm-11.0.1-x86_64-windows-msvc17.7z
-    7z x -y clang+llvm-11.0.1-x86_64-windows-msvc17.7z
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.0.1-x86_64-windows-msvc17
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-windows-msvc17.7z
+    7z x -y clang+llvm-11.1.0-x86_64-windows-msvc17.7z
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-x86_64-windows-msvc17
   fi
 
   if [[ $USE_CUDA -eq 1 ]]; then


### PR DESCRIPTION
The Windows CI seems to have broken; best guess is that MSVC got upgraded and something is now incompatible. I'm hoping a newer binary build of LLVM will fix it.