### PR TITLE
Add support for LLVM 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,18 +16,20 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-18.04', 'macos-10.15', 'windows-2022']
-        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12', '13']
+        llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12', '13', '14']
         cmake: ['0', '1']
         cuda: ['0', '1']
         static: ['0', '1']
         slib: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
-          # Linux: exclude LLVM 13
+          # Linux: exclude LLVM 13-14
           - os: 'ubuntu-18.04'
             llvm: '13'
+          - os: 'ubuntu-18.04'
+            llvm: '14'
 
-          # macOS: exclude LLVM 5.0, 8-13 make, cuda/no-static/no-slib
+          # macOS: exclude LLVM 5.0, 8-14 make, cuda/no-static/no-slib
           - os: 'macos-10.15'
             llvm: '5.0'
           - os: 'macos-10.15'
@@ -47,6 +49,9 @@ jobs:
             cmake: '0'
           - os: 'macos-10.15'
             llvm: '13'
+            cmake: '0'
+          - os: 'macos-10.15'
+            llvm: '14'
             cmake: '0'
           - os: 'macos-10.15'
             cuda: '1'
@@ -117,6 +122,8 @@ jobs:
             cuda: '1'
           - llvm: '13'
             cuda: '1'
+          - llvm: '14'
+            cuda: '1'
 
           # no-static: only LLVM 9
           - llvm: '5.0'
@@ -134,6 +141,8 @@ jobs:
           - llvm: '12'
             static: '0'
           - llvm: '13'
+            static: '0'
+          - llvm: '14'
             static: '0'
 
           # no-slib: only LLVM 9
@@ -153,6 +162,8 @@ jobs:
             slib: '0'
           - llvm: '13'
             slib: '0'
+          - llvm: '14'
+            slib: '0'
 
           # Moonjit: only LLVM 9
           - llvm: '5.0'
@@ -170,6 +181,8 @@ jobs:
           - llvm: '12'
             lua: 'moonjit'
           - llvm: '13'
+            lua: 'moonjit'
+          - llvm: '14'
             lua: 'moonjit'
     steps:
       - uses: actions/checkout@v1
@@ -197,7 +210,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
-        llvm: ['3.8', '6.0', '12', '14']
+        llvm: ['3.8', '6.0', '12', '14.0.0']
         exclude:
           - distro: 'ubuntu-18.04'
             llvm: '3.8'
@@ -214,11 +227,11 @@ jobs:
           - distro: 'ubuntu-20.04'
             llvm: '12'
           - distro: 'ubuntu-16.04'
-            llvm: '14'
+            llvm: '14.0.0'
           - distro: 'ubuntu-18.04'
-            llvm: '14'
+            llvm: '14.0.0'
           - distro: 'ubuntu-20.04'
-            llvm: '14'
+            llvm: '14.0.0'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           - os: 'macos-10.15'
             llvm: '10'
 
-          # Windows: exclude LLVM 5.0-10,12-13, make
+          # Windows: exclude LLVM 5.0-10,12-14, make
           - os: 'windows-2022'
             llvm: '5.0'
           - os: 'windows-2022'
@@ -80,6 +80,8 @@ jobs:
             llvm: '12'
           - os: 'windows-2022'
             llvm: '13'
+          - os: 'windows-2022'
+            llvm: '14'
           - os: 'windows-2022'
             cmake: '0'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -197,7 +197,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
-        llvm: ['3.8', '6.0', '12']
+        llvm: ['3.8', '6.0', '12', '14']
         exclude:
           - distro: 'ubuntu-18.04'
             llvm: '3.8'
@@ -213,6 +213,12 @@ jobs:
             llvm: '12'
           - distro: 'ubuntu-20.04'
             llvm: '12'
+          - distro: 'ubuntu-16.04'
+            llvm: '14'
+          - distro: 'ubuntu-18.04'
+            llvm: '14'
+          - distro: 'ubuntu-20.04'
+            llvm: '14'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ The following changes are included in this release:
 
 ## Added features
 
-  * Support for LLVM 3.8, 3.9, 5, 6, 7, 8, 9, 10, 11, 12 and 13
+  * Support for LLVM 3.8, 3.9, 5, 6, 7, 8, 9, 10, 11, 12, 13 and 14
   * Support for CUDA 9, 10 and 11
   * Support for Visual Studio 2015, 2017, 2019 and 2022 on Windows
   * New CMake-based build system replaces Make/NMake on all platforms
@@ -30,7 +30,7 @@ The following changes are included in this release:
   * Added `terralib.atomicrmw` to support atomic read-modify-write operations
   * Added `terralib.fence` to support fence operations
   * Added `switch` statement
-  * Added support for AMD GPU code generation (with LLVM 13)
+  * Added support for AMD GPU code generation (with LLVM 13 and up)
   * Added support for Nix derivation, and merged upstream into NixOS
 
 ## Deprecated features

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ LLVMVERGT4 := $(shell expr $(LLVM_VERSION) \>= 40)
 
 FLAGS += -DLLVM_VERSION=$(LLVM_VERSION)
 
-LLVM_NEEDS_CXX14="100 110 111 120 130"
+LLVM_NEEDS_CXX14="100 110 111 120 130 140"
 ifneq (,$(findstring $(LLVM_VERSION),$(LLVM_NEEDS_CXX14)))
 CPPFLAGS += -std=c++1y # GCC 5 does not support -std=c++14 flag
 else
@@ -113,7 +113,7 @@ CLANG_LIBS += libclangFrontend.a \
 	libclangLex.a \
 	libclangBasic.a
 
-CLANG_AST_MATCHERS = "80 90 100 110 111 120 130"
+CLANG_AST_MATCHERS = "80 90 100 110 111 120 130 140"
 ifneq (,$(findstring $(LLVM_VERSION),$(CLANG_AST_MATCHERS)))
 CLANG_LIBS += libclangASTMatchers.a
 endif
@@ -129,7 +129,7 @@ else
 	LLVM_LIBFILES := $(shell $(LLVM_CONFIG) --libfiles)
 endif
 
-LLVM_POLLY = "100 110 111 120 130"
+LLVM_POLLY = "100 110 111 120 130 140"
 ifneq (,$(findstring $(LLVM_VERSION),$(LLVM_POLLY)))
 	LLVM_LIBFILES += $(shell $(LLVM_CONFIG) --libdir)/libPolly*.a
 endif

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -143,6 +143,7 @@ The current recommended version of LLVM is **13.0**. The following versions are 
 | 11.0 | :heavy_check_mark: | :heavy_check_mark: | |
 | 12.0 | :heavy_check_mark: | :heavy_check_mark: | |
 | 13.0 | :heavy_check_mark: | :heavy_check_mark: | |
+| 14.0 | :heavy_check_mark: | :heavy_check_mark: | |
 
 The following versions were previously supported by Terra:
 

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -23,7 +23,11 @@
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/Transforms/Scalar.h"
+#if LLVM_VERSION >= 140
+#include "llvm/MC/TargetRegistry.h"
+#else
 #include "llvm/Support/TargetRegistry.h"
+#endif
 #include "llvm/Support/FormattedStream.h"
 #include "llvm/Support/Program.h"
 #include "llvm/Transforms/Utils/Cloning.h"
@@ -44,33 +48,35 @@
 #include "llvm/Object/ObjectFile.h"
 #include "llvm-c/Linker.h"
 
-#if LLVM_VERSION == 38
+#if LLVM_VERSION < 39
 #include "llvmheaders_38.h"
-#elif LLVM_VERSION == 39
+#elif LLVM_VERSION < 40
 #include "llvmheaders_39.h"
-#elif LLVM_VERSION == 50
+#elif LLVM_VERSION < 60
 #include "llvmheaders_50.h"
-#elif LLVM_VERSION == 60
+#elif LLVM_VERSION < 70
 #include "llvmheaders_60.h"
-#elif LLVM_VERSION >= 70 && LLVM_VERSION < 80
+#elif LLVM_VERSION < 80
 #include "llvmheaders_70.h"
-#elif LLVM_VERSION == 80
+#elif LLVM_VERSION < 90
 #include "llvmheaders_80.h"
-#elif LLVM_VERSION == 90
+#elif LLVM_VERSION < 100
 #include "llvmheaders_90.h"
-#elif LLVM_VERSION == 100
+#elif LLVM_VERSION < 110
 #include "llvmheaders_100.h"
-#elif LLVM_VERSION >= 110 && LLVM_VERSION < 120
+#elif LLVM_VERSION < 120
 #include "llvmheaders_110.h"
-#elif LLVM_VERSION == 120
+#elif LLVM_VERSION < 130
 #include "llvmheaders_120.h"
-#elif LLVM_VERSION == 130
+#elif LLVM_VERSION < 140
 #include "llvmheaders_130.h"
+#elif LLVM_VERSION < 150
+#include "llvmheaders_140.h"
 #else
 #error "unsupported LLVM version"
 // for OSX code completion
-#define LLVM_VERSION 100
-#include "llvmheaders_100.h"
+#define LLVM_VERSION 130
+#include "llvmheaders_130.h"
 #endif
 
 #define UNIQUEIFY(T, x) (std::unique_ptr<T>(x))

--- a/src/llvmheaders_140.h
+++ b/src/llvmheaders_140.h
@@ -1,0 +1,34 @@
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Support/Error.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::OF_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::OF_None

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1045,12 +1045,12 @@ struct CCallingConv {
 #elif LLVM_VERSION < 140
         r->addAttribute(idx, Attribute::getWithStructRetType(*CU->TT->ctx, ty));
 #else
-        r->addParamAttr(idx-1, Attribute::getWithStructRetType(*CU->TT->ctx, ty));
+        r->addParamAttr(idx - 1, Attribute::getWithStructRetType(*CU->TT->ctx, ty));
 #endif
 #if LLVM_VERSION < 140
         r->addAttribute(idx, Attribute::NoAlias);
 #else
-        r->addParamAttr(idx-1, Attribute::NoAlias);
+        r->addParamAttr(idx - 1, Attribute::NoAlias);
 #endif
     }
     template <typename FnOrCall>
@@ -1060,19 +1060,19 @@ struct CCallingConv {
 #elif LLVM_VERSION < 140
         r->addAttribute(idx, Attribute::getWithByValType(*CU->TT->ctx, ty));
 #else
-        r->addParamAttr(idx-1, Attribute::getWithByValType(*CU->TT->ctx, ty));
+        r->addParamAttr(idx - 1, Attribute::getWithByValType(*CU->TT->ctx, ty));
 #endif
     }
     template <typename FnOrCall>
-    void addExtAttrIfNeeded(TType *t, FnOrCall *r, int idx, bool return_value=false) {
+    void addExtAttrIfNeeded(TType *t, FnOrCall *r, int idx, bool return_value = false) {
         if (!t->type->isIntegerTy() || t->type->getPrimitiveSizeInBits() >= 32) return;
 #if LLVM_VERSION < 140
         r->addAttribute(idx, t->issigned ? Attribute::SExt : Attribute::ZExt);
 #else
         if (return_value) {
-          r->addRetAttr(t->issigned ? Attribute::SExt : Attribute::ZExt);
+            r->addRetAttr(t->issigned ? Attribute::SExt : Attribute::ZExt);
         } else {
-          r->addParamAttr(idx-1, t->issigned ? Attribute::SExt : Attribute::ZExt);
+            r->addParamAttr(idx - 1, t->issigned ? Attribute::SExt : Attribute::ZExt);
         }
 #endif
     }
@@ -1198,11 +1198,13 @@ struct CCallingConv {
                 } break;
                 case C_AGGREGATE_MEM:
                     // TODO: check that LLVM optimizes this copy away
-                    emitStoreAgg(B, p->type->type, B->CreateLoad(
+                    emitStoreAgg(B, p->type->type,
+                                 B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                                                 p->type->type,
+                                         p->type->type,
 #endif
-                                                                 &*ai), v);
+                                         &*ai),
+                                 v);
                     ++ai;
                     break;
                 case C_AGGREGATE_REG: {
@@ -1241,9 +1243,9 @@ struct CCallingConv {
             }
             B->CreateRet(B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                       result_type,
+                    result_type,
 #endif
-                                       result));
+                    result));
         } else {
             assert(!"unhandled return value");
         }
@@ -1262,9 +1264,9 @@ struct CCallingConv {
         } else {
             arguments.push_back(B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                              value->getType()->getPointerElementType(),
+                    value->getType()->getPointerElementType(),
 #endif
-                                              value));
+                    value));
         }
     }
 
@@ -1333,9 +1335,9 @@ struct CCallingConv {
             }
             return B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                 aggregate->getType()->getPointerElementType(),
+                    aggregate->getType()->getPointerElementType(),
 #endif
-                                 aggregate);
+                    aggregate);
         }
     }
     void GatherArgumentsAggReg(Type *type, std::vector<Type *> &arguments) {
@@ -2032,16 +2034,16 @@ struct FunctionEmitter {
         if (kind == T_add) {
             return B->CreateGEP(
 #if LLVM_VERSION >= 140
-                                pointer->getType()->getPointerElementType(),
+                    pointer->getType()->getPointerElementType(),
 #endif
-                                pointer, number);
+                    pointer, number);
         } else if (kind == T_sub) {
             Value *numNeg = B->CreateNeg(number);
             return B->CreateGEP(
 #if LLVM_VERSION >= 140
-                                pointer->getType()->getPointerElementType(),
+                    pointer->getType()->getPointerElementType(),
 #endif
-                                pointer, numNeg);
+                    pointer, numNeg);
         } else {
             assert(!"unexpected pointer arith");
             return NULL;
@@ -2050,9 +2052,9 @@ struct FunctionEmitter {
     Value *emitPointerSub(TType *t, Value *a, Value *b) {
         return B->CreatePtrDiff(
 #if LLVM_VERSION >= 140
-                                a->getType()->getPointerElementType(),
+                a->getType()->getPointerElementType(),
 #endif
-                                a, b);
+                a, b);
     }
     Value *emitBinary(Obj *exp, Obj *ao, Obj *bo) {
         TType *t = typeOfValue(exp);
@@ -2357,9 +2359,9 @@ struct FunctionEmitter {
             Type *ttype = getType(&type)->type;
             raw = B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                raw->getType()->getPointerElementType(),
+                    raw->getType()->getPointerElementType(),
 #endif
-                                raw);
+                    raw);
         }
         return raw;
     }
@@ -2470,14 +2472,15 @@ struct FunctionEmitter {
                     Ty->EnsurePointsToCompleteType(&aggTypeO);
                     Value *result = B->CreateGEP(
 #if LLVM_VERSION >= 140
-                                                 valueExp->getType()->getPointerElementType(),
+                            valueExp->getType()->getPointerElementType(),
 #endif
-                                                 valueExp, idxExp);
-                    if (!exp->boolean("lvalue")) result = B->CreateLoad(
+                            valueExp, idxExp);
+                    if (!exp->boolean("lvalue"))
+                        result = B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                                                        result->getType()->getPointerElementType(),
+                                result->getType()->getPointerElementType(),
 #endif
-                                                                        result);
+                                result);
                     return result;
                 }
             } break;
@@ -2591,9 +2594,9 @@ struct FunctionEmitter {
                 }
                 return B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                     output->getType()->getPointerElementType(),
+                        output->getType()->getPointerElementType(),
 #endif
-                                     output);
+                        output);
             } break;
             case T_cast: {
                 Obj a;
@@ -2644,11 +2647,12 @@ struct FunctionEmitter {
                 Value *v = emitAddressOf(&obj);
                 Value *result = emitStructSelect(&typ, v, offset);
                 Type *ttype = getType(&typ)->type;
-                if (!exp->boolean("lvalue")) result = B->CreateLoad(
+                if (!exp->boolean("lvalue"))
+                    result = B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                                                    result->getType()->getPointerElementType(),
+                            result->getType()->getPointerElementType(),
 #endif
-                                                                    result);
+                            result);
                 return result;
             } break;
             case T_constructor:
@@ -2700,9 +2704,9 @@ struct FunctionEmitter {
                 Value *v = emitExp(&addr);
                 LoadInst *l = B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                            v->getType()->getPointerElementType(),
+                        v->getType()->getPointerElementType(),
 #endif
-                                            v);
+                        v);
                 if (attr.hasfield("alignment")) {
                     int alignment = attr.number("alignment");
 #if LLVM_VERSION <= 90
@@ -3125,9 +3129,9 @@ struct FunctionEmitter {
         }
         return B->CreateLoad(
 #if LLVM_VERSION >= 140
-                             result->getType()->getPointerElementType(),
+                result->getType()->getPointerElementType(),
 #endif
-                             result);
+                result);
     }
     void emitStmtList(Obj *stmts) {
         int NS = stmts->size();
@@ -3316,9 +3320,9 @@ struct FunctionEmitter {
                 setInsertBlock(cond);
                 Value *v = B->CreateLoad(
 #if LLVM_VERSION >= 140
-                                         vp->getType()->getPointerElementType(),
+                        vp->getType()->getPointerElementType(),
 #endif
-                                         vp);
+                        vp);
                 Value *c = B->CreateOr(B->CreateAnd(emitCompare(T_lt, t, v, limitv),
                                                     emitCompare(T_gt, t, stepv, zero)),
                                        B->CreateAnd(emitCompare(T_gt, t, v, limitv),

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1252,7 +1252,7 @@ struct CCallingConv {
                                arguments);
             }
         } else {
-            arguments.push_back(B->CreateLoad(param_type, value));
+            arguments.push_back(B->CreateLoad(value->getType()->getPointerElementType(), value));
         }
     }
 
@@ -1319,7 +1319,7 @@ struct CCallingConv {
                 if (info.returntype.GetNumberOfTypesInParamList() > 0)
                     B->CreateStore(call, casted);
             }
-            return B->CreateLoad(info.returntype.type->type, aggregate);
+            return B->CreateLoad(aggregate->getType()->getPointerElementType(), aggregate);
         }
     }
     void GatherArgumentsAggReg(Type *type, std::vector<Type *> &arguments) {
@@ -2324,7 +2324,7 @@ struct FunctionEmitter {
             exp->obj("type", &type);
             Ty->EnsureTypeIsComplete(&type);
             Type *ttype = getType(&type)->type;
-            raw = B->CreateLoad(ttype, raw);
+            raw = B->CreateLoad(raw->getType()->getPointerElementType(), raw);
         }
         return raw;
     }
@@ -2546,7 +2546,7 @@ struct FunctionEmitter {
                                       // structvariable and perform any casts necessary
                     B->CreateStore(in, oe);
                 }
-                return B->CreateLoad(toT->type, output);
+                return B->CreateLoad(output->getType()->getPointerElementType(), output);
             } break;
             case T_cast: {
                 Obj a;
@@ -2597,7 +2597,7 @@ struct FunctionEmitter {
                 Value *v = emitAddressOf(&obj);
                 Value *result = emitStructSelect(&typ, v, offset);
                 Type *ttype = getType(&typ)->type;
-                if (!exp->boolean("lvalue")) result = B->CreateLoad(ttype, result);
+                if (!exp->boolean("lvalue")) result = B->CreateLoad(result->getType()->getPointerElementType(), result);
                 return result;
             } break;
             case T_constructor:
@@ -2647,7 +2647,7 @@ struct FunctionEmitter {
                 Ty->EnsureTypeIsComplete(&type);
                 Type *ttype = getType(&type)->type;
                 Value *v = emitExp(&addr);
-                LoadInst *l = B->CreateLoad(ttype, v);
+                LoadInst *l = B->CreateLoad(v->getType()->getPointerElementType(), v);
                 if (attr.hasfield("alignment")) {
                     int alignment = attr.number("alignment");
 #if LLVM_VERSION <= 90
@@ -3068,7 +3068,7 @@ struct FunctionEmitter {
             Value *addr = CreateConstGEP2_32(B, result, 0, i);
             B->CreateStore(values[i], addr);
         }
-        return B->CreateLoad(ttype, result);
+        return B->CreateLoad(result->getType()->getPointerElementType(), result);
     }
     void emitStmtList(Obj *stmts) {
         int NS = stmts->size();
@@ -3255,7 +3255,7 @@ struct FunctionEmitter {
                 BasicBlock *cond = createAndInsertBB("forcond");
                 B->CreateBr(cond);
                 setInsertBlock(cond);
-                Value *v = B->CreateLoad(t->type, vp);
+                Value *v = B->CreateLoad(vp->getType()->getPointerElementType(), vp);
                 Value *c = B->CreateOr(B->CreateAnd(emitCompare(T_lt, t, v, limitv),
                                                     emitCompare(T_gt, t, stepv, zero)),
                                        B->CreateAnd(emitCompare(T_gt, t, v, limitv),

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1042,23 +1042,35 @@ struct CCallingConv {
     void addSRetAttr(FnOrCall *r, int idx, Type *ty) {
 #if LLVM_VERSION < 120
         r->addAttribute(idx, Attribute::StructRet);
-#else
+#elif LLVM_VERSION < 140
         r->addAttribute(idx, Attribute::getWithStructRetType(*CU->TT->ctx, ty));
+#else
+        r->addParamAttr(idx, Attribute::getWithStructRetType(*CU->TT->ctx, ty));
 #endif
+#if LLVM_VERSION < 140
         r->addAttribute(idx, Attribute::NoAlias);
+#else
+        r->addParamAttr(idx, Attribute::NoAlias);
+#endif
     }
     template <typename FnOrCall>
     void addByValAttr(FnOrCall *r, int idx, Type *ty) {
 #if LLVM_VERSION < 120
         r->addAttribute(idx, Attribute::ByVal);
-#else
+#elif LLVM_VERSION < 140
         r->addAttribute(idx, Attribute::getWithByValType(*CU->TT->ctx, ty));
+#else
+        r->addParamAttr(idx, Attribute::getWithByValType(*CU->TT->ctx, ty));
 #endif
     }
     template <typename FnOrCall>
     void addExtAttrIfNeeded(TType *t, FnOrCall *r, int idx) {
         if (!t->type->isIntegerTy() || t->type->getPrimitiveSizeInBits() >= 32) return;
+#if LLVM_VERSION < 140
         r->addAttribute(idx, t->issigned ? Attribute::SExt : Attribute::ZExt);
+#else
+        r->addParamAttr(idx, t->issigned ? Attribute::SExt : Attribute::ZExt);
+#endif
     }
 
     template <typename FnOrCall>
@@ -1182,7 +1194,7 @@ struct CCallingConv {
                 } break;
                 case C_AGGREGATE_MEM:
                     // TODO: check that LLVM optimizes this copy away
-                    emitStoreAgg(B, p->type->type, B->CreateLoad(&*ai), v);
+                    emitStoreAgg(B, p->type->type, B->CreateLoad(p->type->type, &*ai), v);
                     ++ai;
                     break;
                 case C_AGGREGATE_REG: {
@@ -1217,7 +1229,7 @@ struct CCallingConv {
                     result = CreateConstGEP2_32(B, result, 0, 0);
                 } while ((type = dyn_cast<StructType>(type->getElementType(0))));
             }
-            B->CreateRet(B->CreateLoad(result));
+            B->CreateRet(B->CreateLoad(type, result));
         } else {
             assert(!"unhandled return value");
         }
@@ -1234,7 +1246,7 @@ struct CCallingConv {
                                arguments);
             }
         } else {
-            arguments.push_back(B->CreateLoad(value));
+            arguments.push_back(B->CreateLoad(param_type, value));
         }
     }
 
@@ -1301,7 +1313,7 @@ struct CCallingConv {
                 if (info.returntype.GetNumberOfTypesInParamList() > 0)
                     B->CreateStore(call, casted);
             }
-            return B->CreateLoad(aggregate);
+            return B->CreateLoad(info.returntype.type->type, aggregate);
         }
     }
     void GatherArgumentsAggReg(Type *type, std::vector<Type *> &arguments) {
@@ -1996,16 +2008,16 @@ struct FunctionEmitter {
     Value *emitPointerArith(T_Kind kind, Value *pointer, TType *numTy, Value *number) {
         number = emitIndex(numTy, 64, number);
         if (kind == T_add) {
-            return B->CreateGEP(pointer, number);
+            return B->CreateGEP(pointer->getType(), pointer, number);
         } else if (kind == T_sub) {
             Value *numNeg = B->CreateNeg(number);
-            return B->CreateGEP(pointer, numNeg);
+            return B->CreateGEP(pointer->getType(), pointer, numNeg);
         } else {
             assert(!"unexpected pointer arith");
             return NULL;
         }
     }
-    Value *emitPointerSub(TType *t, Value *a, Value *b) { return B->CreatePtrDiff(a, b); }
+    Value *emitPointerSub(TType *t, Value *a, Value *b) { return B->CreatePtrDiff(t->type, a, b); }
     Value *emitBinary(Obj *exp, Obj *ao, Obj *bo) {
         TType *t = typeOfValue(exp);
         T_Kind kind = exp->kind("operator");
@@ -2306,7 +2318,8 @@ struct FunctionEmitter {
             Obj type;
             exp->obj("type", &type);
             Ty->EnsureTypeIsComplete(&type);
-            raw = B->CreateLoad(raw);
+            Type *ttype = getType(&type)->type;
+            raw = B->CreateLoad(ttype, raw);
         }
         return raw;
     }
@@ -2415,8 +2428,8 @@ struct FunctionEmitter {
                     // otherwise we have a pointer access which will use a GEP instruction
                     std::vector<Value *> idxs;
                     Ty->EnsurePointsToCompleteType(&aggTypeO);
-                    Value *result = B->CreateGEP(valueExp, idxExp);
-                    if (!exp->boolean("lvalue")) result = B->CreateLoad(result);
+                    Value *result = B->CreateGEP(aggType->type, valueExp, idxExp);
+                    if (!exp->boolean("lvalue")) result = B->CreateLoad(cast<PointerType>(result->getType())->getElementType(), result);
                     return result;
                 }
             } break;
@@ -2528,7 +2541,7 @@ struct FunctionEmitter {
                                       // structvariable and perform any casts necessary
                     B->CreateStore(in, oe);
                 }
-                return B->CreateLoad(output);
+                return B->CreateLoad(toT->type, output);
             } break;
             case T_cast: {
                 Obj a;
@@ -2578,7 +2591,8 @@ struct FunctionEmitter {
 
                 Value *v = emitAddressOf(&obj);
                 Value *result = emitStructSelect(&typ, v, offset);
-                if (!exp->boolean("lvalue")) result = B->CreateLoad(result);
+                Type *ttype = getType(&typ)->type;
+                if (!exp->boolean("lvalue")) result = B->CreateLoad(ttype, result);
                 return result;
             } break;
             case T_constructor:
@@ -2626,7 +2640,9 @@ struct FunctionEmitter {
                 exp->obj("address", &addr);
                 exp->obj("attrs", &attr);
                 Ty->EnsureTypeIsComplete(&type);
-                LoadInst *l = B->CreateLoad(emitExp(&addr));
+                Type *ttype = getType(&type)->type;
+                Value *v = emitExp(&addr);
+                LoadInst *l = B->CreateLoad(ttype, v);
                 if (attr.hasfield("alignment")) {
                     int alignment = attr.number("alignment");
 #if LLVM_VERSION <= 90
@@ -3039,14 +3055,15 @@ struct FunctionEmitter {
         }
     }
     Value *emitConstructor(Obj *exp, Obj *expressions) {
-        Value *result = CreateAlloca(B, typeOfValue(exp)->type);
+        Type *ttype = typeOfValue(exp)->type;
+        Value *result = CreateAlloca(B, ttype);
         std::vector<Value *> values;
         emitExpressionList(expressions, true, &values);
         for (size_t i = 0; i < values.size(); i++) {
             Value *addr = CreateConstGEP2_32(B, result, 0, i);
             B->CreateStore(values[i], addr);
         }
-        return B->CreateLoad(result);
+        return B->CreateLoad(ttype, result);
     }
     void emitStmtList(Obj *stmts) {
         int NS = stmts->size();
@@ -3233,7 +3250,7 @@ struct FunctionEmitter {
                 BasicBlock *cond = createAndInsertBB("forcond");
                 B->CreateBr(cond);
                 setInsertBlock(cond);
-                Value *v = B->CreateLoad(vp);
+                Value *v = B->CreateLoad(t->type, vp);
                 Value *c = B->CreateOr(B->CreateAnd(emitCompare(T_lt, t, v, limitv),
                                                     emitCompare(T_gt, t, stepv, zero)),
                                        B->CreateAnd(emitCompare(T_gt, t, v, limitv),

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2023,7 +2023,9 @@ struct FunctionEmitter {
             return NULL;
         }
     }
-    Value *emitPointerSub(TType *t, Value *a, Value *b) { return B->CreatePtrDiff(t->type, a, b); }
+    Value *emitPointerSub(TType *t, Value *a, Value *b) {
+        return B->CreatePtrDiff(a->getType()->getPointerElementType(), a, b);
+    }
     Value *emitBinary(Obj *exp, Obj *ao, Obj *bo) {
         TType *t = typeOfValue(exp);
         T_Kind kind = exp->kind("operator");

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2057,6 +2057,7 @@ struct FunctionEmitter {
         if (at->type->isPointerTy() && (kind == T_add || kind == T_sub)) {
             Ty->EnsurePointsToCompleteType(&aot);
             if (bt->type->isPointerTy()) {
+                assert(kind == T_sub);
                 return emitPointerSub(t, a, b);
             } else {
                 assert(bt->type->isIntegerTy());

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -279,7 +279,7 @@ struct CopyConnectedComponent : public ValueMaterializer {
             GlobalVariable *newGV = dest->getGlobalVariable(GV->getName(), true);
             if (!newGV || needsFreshlyNamedConstant(GV, newGV)) {
                 newGV = new GlobalVariable(
-                        *dest, GV->getType()->getElementType(), GV->isConstant(),
+                        *dest, GV->getType()->getPointerElementType(), GV->isConstant(),
                         GV->getLinkage(), NULL, GV->getName(), NULL,
                         GlobalVariable::NotThreadLocal, GV->getType()->getAddressSpace());
                 newGV->copyAttributesFrom(GV);

--- a/travis.sh
+++ b/travis.sh
@@ -89,7 +89,13 @@ if [[ $(uname) = Linux ]]; then
 fi
 
 if [[ $(uname) = Darwin ]]; then
-  if [[ $LLVM_CONFIG = llvm-config-13 ]]; then
+  if [[ $LLVM_CONFIG = llvm-config-14 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz
+    tar xf clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz
+    ln -s clang+llvm-14.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-14
+    ln -s clang+llvm-14.0.0-x86_64-apple-darwin/bin/clang clang-14
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.0-x86_64-apple-darwin
+  elif [[ $LLVM_CONFIG = llvm-config-13 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-13.0.0/clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz
     tar xf clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz
     ln -s clang+llvm-13.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-13
@@ -163,7 +169,11 @@ if [[ $(uname) = Darwin ]]; then
 fi
 
 if [[ $(uname) = MINGW* ]]; then
-  if [[ $LLVM_CONFIG = llvm-config-11 ]]; then
+  if [[ $LLVM_CONFIG = llvm-config-14 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-x86_64-windows-msvc17.7z
+    7z x -y clang+llvm-14.0.0-x86_64-windows-msvc17.7z
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.0-x86_64-windows-msvc17
+  elif [[ $LLVM_CONFIG = llvm-config-11 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-windows-msvc17.7z
     7z x -y clang+llvm-11.1.0-x86_64-windows-msvc17.7z
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-x86_64-windows-msvc17

--- a/travis.sh
+++ b/travis.sh
@@ -20,7 +20,13 @@ if [[ $CHECK_CLANG_FORMAT -eq 1 ]]; then
 fi
 
 if [[ -n $DOCKER_BUILD ]]; then
-    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM $( [[ $DOCKER_LLVM = "3.8" || $DOCKER_LLVM = "14" ]] && echo upstream )
+    variant=
+    if [[ $DOCKER_LLVM = "3.8" ]]; then
+        variant=upstream
+    elif [[ $DOCKER_LLVM = *"."*"."* ]]; then
+        variant=prebuilt
+    fi
+    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM $variant
     exit 0
 fi
 

--- a/travis.sh
+++ b/travis.sh
@@ -20,7 +20,7 @@ if [[ $CHECK_CLANG_FORMAT -eq 1 ]]; then
 fi
 
 if [[ -n $DOCKER_BUILD ]]; then
-    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM $( [[ $DOCKER_LLVM = "3.8" ]] && echo upstream )
+    ./docker/build.sh $DOCKER_BUILD $DOCKER_LLVM $( [[ $DOCKER_LLVM = "3.8" || $DOCKER_LLVM = "14" ]] && echo upstream )
     exit 0
 fi
 


### PR DESCRIPTION
At some point we need to come back and seriously think about how to architect the compiler for opaque pointers. But for now, non-opaque pointers aren't gone yet, so we'll just take advantage of that to get by.

Passes on my local machine.