### PR TITLE
Deprecate LLVM <= 5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,7 @@ The following changes are included in this release:
 ## Deprecated features
 
   * Deprecated support for Make (Linux, macOS) build system
+  * Deprecated support for LLVM 3.8, 3.9 and 5
 
 ## Removed features
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -132,9 +132,9 @@ The current recommended version of LLVM is **13**. The following versions are al
 
 | Version | Linux | macOS | Windows | CUDA | AMD GPU \* | Notes |
 | ------- | ----- | ----- | ------- | ---- | ---------- | ----- |
-| 3.8 | :heavy_check_mark: | :heavy_check_mark: | | :heavy_check_mark: | | |
-| 3.9 | :heavy_check_mark: | :heavy_check_mark: | | | | |
-| 5 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | | |
+| 3.8 | :heavy_check_mark: | :heavy_check_mark: | | :heavy_check_mark: | | [deprecated](https://github.com/terralang/terra/issues/471) |
+| 3.9 | :heavy_check_mark: | :heavy_check_mark: | | | | [deprecated](https://github.com/terralang/terra/issues/471) |
+| 5 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | | [deprecated](https://github.com/terralang/terra/issues/471) |
 | 6 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | | |
 | 7 | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | | requires CMake |
 | 8 | :heavy_check_mark: | :heavy_check_mark: | | :heavy_check_mark: | | |


### PR DESCRIPTION
This is the formal deprecation of LLVM <= 5, per #471.

No code removals. Only documentation changes at this time.