### PR TITLE
Update LuaJIT and set default (except on PPC64le)

### DIFF
--- a/cmake/Modules/GetLuaJIT.cmake
+++ b/cmake/Modules/GetLuaJIT.cmake
@@ -1,6 +1,13 @@
 include(FindPackageHandleStandardArgs)
 
-set(TERRA_LUA moonjit CACHE STRING "Build Terra against the specified Lua implementation")
+if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+  # Moonjit is archived, but we need it to build on PPC64le.
+  set(DEFAULT_TERRA_LUA "moonjit")
+else()
+  set(DEFAULT_TERRA_LUA "luajit")
+endif()
+
+set(TERRA_LUA "${DEFAULT_TERRA_LUA}" CACHE STRING "Build Terra against the specified Lua implementation")
 
 if(TERRA_LUA STREQUAL "luajit")
   set(LUAJIT_NAME "LuaJIT")
@@ -9,7 +16,7 @@ if(TERRA_LUA STREQUAL "luajit")
   set(LUAJIT_VERSION_MINOR 1)
   set(LUAJIT_VERSION_PATCH 0)
   set(LUAJIT_VERSION_EXTRA -beta3)
-  set(LUAJIT_COMMIT "9143e86498436892cb4316550be4d45b68a61224")
+  set(LUAJIT_COMMIT "6053b04815ecbc8eec1e361ceb64e68fb8fac1b3")
   if(NOT LUAJIT_VERSION_COMMIT STREQUAL "")
     set(LUAJIT_URL_PREFIX "https://github.com/LuaJIT/LuaJIT/archive/")
   else()
@@ -26,6 +33,12 @@ elseif(TERRA_LUA STREQUAL "moonjit")
   set(LUAJIT_URL_PREFIX "https://github.com/moonjit/moonjit/archive/")
 else()
   message(FATAL_ERROR "TERRA_LUA must be one of 'luajit', 'moonjit'")
+endif()
+
+if(NOT LUAJIT_VERSION_COMMIT STREQUAL "")
+  message(STATUS "Using Lua: ${LUAJIT_NAME} commit ${LUAJIT_COMMIT}")
+else()
+  message(STATUS "Using Lua: ${LUAJIT_NAME} release ${LUAJIT_VERSION_MAJOR}.${LUAJIT_VERSION_MINOR}.${LUAJIT_VERSION_PATCH}${LUAJIT_VERSION_EXTRA}")
 endif()
 
 if(NOT LUAJIT_VERSION_COMMIT STREQUAL "")
@@ -270,6 +283,7 @@ add_custom_target(
 )
 
 mark_as_advanced(
+  DEFAULT_TERRA_LUA
   LUAJIT_BASENAME
   LUAJIT_URL
   LUAJIT_TAR

--- a/default.nix
+++ b/default.nix
@@ -14,14 +14,14 @@ let
            cudaPackages.cuda_cudart
          ];
 
-  luajitRev = "9143e86498436892cb4316550be4d45b68a61224";
+  luajitRev = "6053b04815ecbc8eec1e361ceb64e68fb8fac1b3";
   luajitBase = "LuaJIT-${luajitRev}";
   luajitArchive = "${luajitBase}.tar.gz";
   luajitSrc = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
     rev = luajitRev;
-    sha256 = "1zw1yr0375d6jr5x20zvkvk76hkaqamjynbswpl604w6r6id070b";
+    sha256 = "1caxm1js877mky8hci1km3ycz2hbwpm6xbyjha72gfc7lr6pc429";
   };
   llvmMerged = symlinkJoin {
     name = "llvmClangMerged";
@@ -43,7 +43,7 @@ let
 
 in stdenv.mkDerivation rec {
   pname = "terra";
-  version = "1.0.0-beta3";
+  version = "1.0.0";
 
   src = ./.;
 


### PR DESCRIPTION
I'm splitting this out from #566 to be tested separately. Newer LuaJIT has fixes for ARM64 needed to run Terra, but may also provide benefits on other platforms.

I'm also changing the default Lua back to LuaJIT on all platforms except PPC64le, since Moonjit has been archived. PPC64le is the only architecture where we really can't drop support for it.