### PR TITLE
Install libterra.so with system-standard name and symlink terra.so for other users

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,7 +99,7 @@ ifneq ($(findstring $(UNAME), Linux FreeBSD),)
 DYNFLAGS = -shared -fPIC
 TERRA_STATIC_LIBRARY += -Wl,-export-dynamic -Wl,--whole-archive $(LIBRARY) -Wl,--no-whole-archive
 else
-DYNFLAGS = -dynamiclib -single_module -fPIC -install_name "@rpath/terra.dylib"
+DYNFLAGS = -dynamiclib -single_module -fPIC -install_name "@rpath/libterra.dylib"
 TERRA_STATIC_LIBRARY =  -Wl,-force_load,$(LIBRARY)
 endif
 
@@ -207,9 +207,11 @@ LIBRARY_NOLUA = release/lib/libterra_nolua.a
 LIBRARY_NOLUA_NOLLVM = release/lib/libterra_nolua_nollvm.a
 LIBRARY_VARIANTS = $(LIBRARY_NOLUA) $(LIBRARY_NOLUA_NOLLVM)
 ifeq ($(UNAME), Darwin)
-DYNLIBRARY = release/lib/terra.dylib
+DYNLIBRARY = release/lib/libterra.dylib
+DYNLIBRARY_LINK = release/lib/terra.dylib
 else
-DYNLIBRARY = release/lib/terra.so
+DYNLIBRARY = release/lib/libterra.so
+DYNLIBRARY_LINK = release/lib/terra.so
 endif
 RELEASE_HEADERS = $(addprefix release/include/terra/,$(LUAHEADERS))
 BIN2C = build/bin2c
@@ -218,7 +220,7 @@ BIN2C = build/bin2c
 -include Makefile.inc
 
 .PHONY:	all clean download purge test release install
-all:	$(EXECUTABLE) $(DYNLIBRARY)
+all:	$(EXECUTABLE) $(DYNLIBRARY) $(DYNLIBRARY_LINK)
 
 test:	all
 	(cd tests; ./run)
@@ -284,6 +286,9 @@ $(LIBRARY_NOLUA_NOLLVM):	$(RELEASE_HEADERS) $(addprefix build/, $(LIBOBJS))
 $(DYNLIBRARY):	$(LIBRARY)
 	$(CXX) $(DYNFLAGS) $(TERRA_STATIC_LIBRARY) $(SUPPORT_LIBRARY_FLAGS) -o $@  
 
+$(DYNLIBRARY_LINK):	$(DYNLIBRARY)
+	ln -s $(basename $(DYNLIBRARY)) $(DYNLIBRARY_LINK)
+
 $(EXECUTABLE):	$(addprefix build/, $(EXEOBJS)) $(LIBRARY)
 	mkdir -p release/bin release/lib
 	$(CXX) $(addprefix build/, $(EXEOBJS)) -o $@ $(LFLAGS) $(TERRA_STATIC_LIBRARY)  $(SUPPORT_LIBRARY_FLAGS)
@@ -304,7 +309,7 @@ build/internalizedfiles.h:	$(PACKAGE_DEPS) src/geninternalizedfiles.lua lib/std.
 
 clean:
 	rm -rf build/*.o build/*.d $(GENERATEDHEADERS)
-	rm -rf $(EXECUTABLE) terra $(LIBRARY) $(LIBRARY_NOLUA) $(LIBRARY_NOLUA_NOLLVM) $(DYNLIBRARY) $(RELEASE_HEADERS) build/llvm_objects build/lua_objects
+	rm -rf $(EXECUTABLE) terra $(LIBRARY) $(LIBRARY_NOLUA) $(LIBRARY_NOLUA_NOLLVM) $(DYNLIBRARY) $(DYNLIBRARY_LINK) $(RELEASE_HEADERS) build/llvm_objects build/lua_objects
 
 purge:	clean
 	rm -rf build/*

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -220,8 +220,6 @@ add_dependencies(TerraLibrary LLVMObjectFiles)
 add_dependencies(TerraLibraryShared LuaJIT)
 add_dependencies(TerraLibraryShared LLVMObjectFiles)
 
-set_target_properties(TerraLibraryShared PROPERTIES PREFIX "")
-
 set_target_properties(TerraLibrary PROPERTIES OUTPUT_NAME terra_s)
 set_target_properties(TerraLibraryShared PROPERTIES OUTPUT_NAME terra)
 
@@ -257,6 +255,30 @@ if(WIN32)
   target_link_options(TerraLibraryShared
     PRIVATE
       ${TERRA_EXPORTS}
+  )
+endif()
+
+# Lua expects Terra to generate an unprefixed terra.so/dylib.
+if(NOT CMAKE_SHARED_LIBRARY_PREFIX STREQUAL "")
+  add_custom_command(
+    OUTPUT "${PROJECT_BINARY_DIR}/lib/terra${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    DEPENDS
+      TerraLibraryShared
+    COMMAND ${CMAKE_COMMAND} -E create_symlink "${CMAKE_SHARED_LIBRARY_PREFIX}terra${CMAKE_SHARED_LIBRARY_SUFFIX}" "terra${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/lib
+    VERBATIM
+  )
+
+  add_custom_target(
+    TerraLibrarySymlink
+    ALL
+    DEPENDS
+      "${PROJECT_BINARY_DIR}/lib/terra${CMAKE_SHARED_LIBRARY_SUFFIX}"
+  )
+
+  install(
+    FILES "${PROJECT_BINARY_DIR}/lib/terra${CMAKE_SHARED_LIBRARY_SUFFIX}"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}
   )
 endif()
 

--- a/tests/dynlib.t
+++ b/tests/dynlib.t
@@ -41,7 +41,7 @@ if ffi.os ~= "Windows" then
       libext = ".dylib"
     end
 
-    local libname = "terra"..libext
+    local libname = "libterra"..libext
 
     local flags = terralib.newlist {"-Wl,-rpath,"..libpath,libpath.."/"..libname}
     local lua_lib = libpath.."/".."libluajit-5.1"..libext


### PR DESCRIPTION
Historically Terra has installed itself as `terra.so` on Unix, even though the system convention would be `libterra.so`. I believe at the time the reason was for compatibility with Lua, where modules are expected to be unprefixed (e.g., you can `require("terra")` to load `terra.so` automatically).

We don't currently have a test case for this, but you can verify this behavior manually with (after a build):

```
$ cd lib
$ ../luajit/bin/luajit-2.1.0-beta3 
LuaJIT 2.1.0-beta3 -- Copyright (C) 2005-2022 Mike Pall. https://luajit.org/
JIT: ON SSE3 SSE4.1 BMI2 fold cse dce fwd dse narrow loop abc sink fuse
> require("terra")
> 
```

This change makes `libterra.so` the default in CMake, but adds a target to symlink this to `terra.so` for compatibility with the Lua convention. This should benefit most users on Unix who (aside from LuaJIT) expect libraries to be prefixed with `lib`.