### PR TITLE
More fixes for PPC64le calling convention

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1386,7 +1386,11 @@ struct CCallingConv {
                     EmitCallAggReg(B, casted, a->cctype, arguments);
                 } break;
                 case C_ARRAY_REG: {
-                    assert(false && "unimplemented");
+                    Value *scratch = CreateAlloca(B, a->type->type);
+                    unsigned as = scratch->getType()->getPointerAddressSpace();
+                    emitStoreAgg(B, a->type->type, actual, scratch);
+                    Value *casted = B->CreateBitCast(scratch, Ptr(a->cctype, as));
+                    EmitCallAggReg(B, casted, a->cctype, arguments);
                 } break;
                 default: {
                     assert(!"unhandled argument kind");

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1431,7 +1431,7 @@ struct CCallingConv {
                 unsigned as = aggregate->getType()->getPointerAddressSpace();
                 ArrayType *type = cast<ArrayType>(info.returntype.cctype);
                 Value *casted = B->CreateBitCast(aggregate, Ptr(type, as));
-                B->CreateStore(call, casted);
+                emitStoreAgg(B, type, call, casted);
             } else {
                 assert(!"unhandled argument kind");
             }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1334,7 +1334,16 @@ struct CCallingConv {
 #endif
                     result));
         } else if (C_ARRAY_REG == kind) {
-          assert(false && "unimplemented");
+            Value *dest = CreateAlloca(B, info->returntype.type->type);
+            unsigned as = dest->getType()->getPointerAddressSpace();
+            emitStoreAgg(B, info->returntype.type->type, result, dest);
+            ArrayType *result_type = cast<ArrayType>(info->returntype.cctype);
+            Value *result = B->CreateBitCast(dest, Ptr(type, as));
+            B->CreateRet(B->CreateLoad(
+#if LLVM_VERSION >= 80
+                    result_type,
+#endif
+                    result));
         } else {
             assert(!"unhandled return value");
         }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -999,13 +999,21 @@ struct CCallingConv {
                 // Special cases: all-float or all-double up to 8 values via registers
                 if (all_float && /* *usedint + */ st->getNumElements() <= 8) {
                     *usedint += st->getNumElements();
-                    auto at = ArrayType::get(Type::getFloatTy(*CU->TT->ctx), st->getNumElements());
-                    return Argument(C_ARRAY_REG, t, at);
+                    if (st->getNumElements() == 1) {
+                        return Argument(C_AGGREGATE_REG, t, t->type);
+                    } else {
+                        auto at = ArrayType::get(Type::getFloatTy(*CU->TT->ctx), st->getNumElements());
+                        return Argument(C_ARRAY_REG, t, at);
+                    }
                 }
                 if (all_double && /* *usedint + */ st->getNumElements() <= 8) {
                     *usedint += st->getNumElements();
-                    auto at = ArrayType::get(Type::getDoubleTy(*CU->TT->ctx), st->getNumElements());
-                    return Argument(C_ARRAY_REG, t, at);
+                    if (st->getNumElements() == 1) {
+                        return Argument(C_AGGREGATE_REG, t, t->type);
+                    } else {
+                        auto at = ArrayType::get(Type::getDoubleTy(*CU->TT->ctx), st->getNumElements());
+                        return Argument(C_ARRAY_REG, t, at);
+                    }
                 }
 
                 // Integer or mixed-integer-float case:

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -998,18 +998,22 @@ struct CCallingConv {
                 // Special cases: all-float or all-double up to 8 values via registers
                 if (all_float && /* *usedint + */ st->getNumElements() <= 8) {
                     *usedint += st->getNumElements();
-                    // FIXME: needs to be: // ArrayType::get(Type::getFloatTy(*CU->TT->ctx), st->getNumElements())
-                    return Argument(C_AGGREGATE_REG, t,  t->type);
+                    // FIXME: needs to be: //
+                    // ArrayType::get(Type::getFloatTy(*CU->TT->ctx),
+                    // st->getNumElements())
+                    return Argument(C_AGGREGATE_REG, t, t->type);
                 }
                 if (all_double && /* *usedint + */ st->getNumElements() <= 8) {
                     *usedint += st->getNumElements();
-                    // FIXME: needs to be: ArrayType::get(Type::getDoubleTy(*CU->TT->ctx), st->getNumElements())
+                    // FIXME: needs to be: ArrayType::get(Type::getDoubleTy(*CU->TT->ctx),
+                    // st->getNumElements())
                     return Argument(C_AGGREGATE_REG, t, t->type);
                 }
 
                 // Integer or mixed-integer-float case:
 
-                // Can pack up to 8 registers, or 2 if this is a return. (A register is 64 bits.)
+                // Can pack up to 8 registers, or 2 if this is a return. (A register is 64
+                // bits.)
                 int sz = (CU->getDataLayout().getTypeAllocSize(t->type) + 7) / 8;
                 int limit = isreturn ? 2 : 8;
                 if (*usedint + sz <= limit) {
@@ -1021,7 +1025,7 @@ struct CCallingConv {
                     for (auto elt : st->elements()) {
                         unsigned b = elt->getScalarSizeInBits();
                         bits += b;
-                        bits = (bits + b - 1) & (-(int)b); // Align to this type.
+                        bits = (bits + b - 1) & (-(int)b);  // Align to this type.
                         if (bits >= 64) {
                             elements.push_back(Type::getIntNTy(*CU->TT->ctx, 64));
                             bits -= 64;
@@ -1029,9 +1033,11 @@ struct CCallingConv {
                     }
                     if (bits > 0) {
                         // Align to the biggest type we've seen.
-                        elements.push_back(Type::getIntNTy(*CU->TT->ctx, (bits + alignment - 1) & (-alignment)));
+                        elements.push_back(Type::getIntNTy(
+                                *CU->TT->ctx, (bits + alignment - 1) & (-alignment)));
                     }
-                    return Argument(C_AGGREGATE_REG, t, StructType::get(*CU->TT->ctx, elements));
+                    return Argument(C_AGGREGATE_REG, t,
+                                    StructType::get(*CU->TT->ctx, elements));
                 }
                 return Argument(C_AGGREGATE_MEM, t);
             }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -974,7 +974,7 @@ struct CCallingConv {
         for (auto elt : st->elements()) {
             StructType *elt_st = dyn_cast<StructType>(elt);
             if (elt_st) {
-                CountPPC64Arguments(elt_st, all_float, all_double, num_elts, alignment);
+                CountArgumentsPPC64(elt_st, all_float, all_double, num_elts, alignment);
             } else {
                 all_float = all_float && elt->isFloatTy();
                 all_double = all_double && elt->isDoubleTy();
@@ -1024,7 +1024,7 @@ struct CCallingConv {
                 bool all_double = true;
                 int num_elts = 0;
                 int alignment = 0;
-                CountPPC64Arguments(st, all_float, all_double, num_elts, alignment);
+                CountArgumentsPPC64(st, all_float, all_double, num_elts, alignment);
                 // Special cases: all-float or all-double up to 8 values via registers
                 if (all_float && num_elts <= 8) {
                     *usedint += num_elts;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1025,7 +1025,7 @@ struct CCallingConv {
         }
     }
 
-    Argument PackAggPPC64(TType *t, int *usedfloat, int *usedint, bool isreturn) {
+    Argument ClassifyAggPPC64(TType *t, int *usedfloat, int *usedint, bool isreturn) {
         bool all_float = true;
         bool all_double = true;
         int n_elts = 0;
@@ -1092,7 +1092,7 @@ struct CCallingConv {
         }
 
         if (ppc64_cconv) {
-            return PackAggPPC64(t, usedfloat, usedint, isreturn);
+            return ClassifyAggPPC64(t, usedfloat, usedint, isreturn);
         }
 
         int sz = CU->getDataLayout().getTypeAllocSize(t->type);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1304,7 +1304,13 @@ struct CCallingConv {
                     unsigned as = scratch->getType()->getPointerAddressSpace();
                     emitStoreAgg(B, p->cctype, &*ai, scratch);
                     Value *casted = B->CreateBitCast(scratch, Ptr(p->type->type, as));
-                    emitStoreAgg(B, p->type->type, casted, v);
+                    emitStoreAgg(B, p->type->type,
+                                 B->CreateLoad(
+#if LLVM_VERSION >= 80
+                                               p->type->type,
+#endif
+                                               casted),
+                                 v);
                     ++ai;
                 } break;
             }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1497,7 +1497,7 @@ struct CCallingConv {
                     GatherArgumentsAggReg(a->cctype, arguments);
                 } break;
                 case C_ARRAY_REG: {
-                    assert(false && "unimplemented");
+                    arguments.push_back(a->cctype);
                 } break;
                 default: {
                     assert(!"unhandled argument kind");

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1292,7 +1292,12 @@ struct CCallingConv {
                     EmitEntryAggReg(B, dest, p->cctype, ai);
                 } break;
                 case C_ARRAY_REG: {
-                  assert(false && "unimplemented");
+                    Value *scratch = CreateAlloca(B, p->cctype);
+                    unsigned as = scratch->getType()->getPointerAddressSpace();
+                    emitStoreAgg(B, p->cctype, &*ai, scratch);
+                    Value *casted = B->CreateBitCast(scratch, Ptr(p->type->type, as));
+                    emitStoreAgg(B, p->type->type, casted, v);
+                    ++ai;
                 } break;
             }
         }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -974,7 +974,7 @@ struct CCallingConv {
         StructType *st = dyn_cast<StructType>(t);
         if (st) {
             for (auto elt : st->elements()) {
-                CountArgumentsPPC64(st, all_float, all_double, num_elts, alignment);
+                CountArgumentsPPC64(elt, all_float, all_double, num_elts, alignment);
             }
             return;
         }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1423,7 +1423,11 @@ struct CCallingConv {
                 if (info.returntype.GetNumberOfTypesInParamList() > 0)
                     B->CreateStore(call, casted);
             } else if (C_ARRAY_REG == info.returntype.kind) {
-                assert(false && "unimplemented");
+                aggregate = CreateAlloca(B, info.returntype.type->type);
+                unsigned as = aggregate->getType()->getPointerAddressSpace();
+                ArrayType *type = cast<ArrayType>(info.returntype.cctype);
+                Value *casted = B->CreateBitCast(aggregate, Ptr(type, as));
+                B->CreateStore(call, casted);
             } else {
                 assert(!"unhandled argument kind");
             }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1014,7 +1014,7 @@ struct CCallingConv {
             return;
         }
 
-        unsigned b = CU->getDataLayout().getTypeAllocSizeInBits(elt);
+        unsigned b = CU->getDataLayout().getTypeAllocSizeInBits(t);
         bits += b;
         bits = (bits + b - 1) & (-(int)b);  // Align to this type.
         if (bits >= 64) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1002,7 +1002,8 @@ struct CCallingConv {
                     if (st->getNumElements() == 1) {
                         return Argument(C_AGGREGATE_REG, t, t->type);
                     } else {
-                        auto at = ArrayType::get(Type::getFloatTy(*CU->TT->ctx), st->getNumElements());
+                        auto at = ArrayType::get(Type::getFloatTy(*CU->TT->ctx),
+                                                 st->getNumElements());
                         return Argument(C_ARRAY_REG, t, at);
                     }
                 }
@@ -1011,7 +1012,8 @@ struct CCallingConv {
                     if (st->getNumElements() == 1) {
                         return Argument(C_AGGREGATE_REG, t, t->type);
                     } else {
-                        auto at = ArrayType::get(Type::getDoubleTy(*CU->TT->ctx), st->getNumElements());
+                        auto at = ArrayType::get(Type::getDoubleTy(*CU->TT->ctx),
+                                                 st->getNumElements());
                         return Argument(C_ARRAY_REG, t, at);
                     }
                 }
@@ -1307,9 +1309,9 @@ struct CCallingConv {
                     emitStoreAgg(B, p->type->type,
                                  B->CreateLoad(
 #if LLVM_VERSION >= 80
-                                               p->type->type,
+                                         p->type->type,
 #endif
-                                               casted),
+                                         casted),
                                  v);
                     ++ai;
                 } break;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -850,7 +850,7 @@ struct CCallingConv {
         C_PRIMITIVE,      // passed without modifcation (i.e. any non-aggregate type)
         C_AGGREGATE_REG,  // aggregate passed through registers
         C_AGGREGATE_MEM,  // aggregate passed through memory
-        C_ARRAY_REG,      // array passed through registers
+        C_ARRAY_REG,      // aggregate passed through registers as an array
     };
 
     struct Argument {
@@ -1470,7 +1470,7 @@ struct CCallingConv {
                 arguments.push_back(Ptr(info->returntype.type->type));
             } break;
             case C_ARRAY_REG: {
-                assert(false && "unimplemented");
+                rt = info->returntype.cctype;
             } break;
             case C_PRIMITIVE: {
                 rt = info->returntype.cctype;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1338,7 +1338,7 @@ struct CCallingConv {
             unsigned as = dest->getType()->getPointerAddressSpace();
             emitStoreAgg(B, info->returntype.type->type, result, dest);
             ArrayType *result_type = cast<ArrayType>(info->returntype.cctype);
-            Value *result = B->CreateBitCast(dest, Ptr(type, as));
+            Value *result = B->CreateBitCast(dest, Ptr(result_type, as));
             B->CreateRet(B->CreateLoad(
 #if LLVM_VERSION >= 80
                     result_type,

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -998,16 +998,13 @@ struct CCallingConv {
                 // Special cases: all-float or all-double up to 8 values via registers
                 if (all_float && /* *usedint + */ st->getNumElements() <= 8) {
                     *usedint += st->getNumElements();
-                    // FIXME: needs to be: //
-                    // ArrayType::get(Type::getFloatTy(*CU->TT->ctx),
-                    // st->getNumElements())
-                    return Argument(C_AGGREGATE_REG, t, t->type);
+                    auto at = ArrayType::get(Type::getFloatTy(*CU->TT->ctx), st->getNumElements());
+                    return Argument(C_ARRAY_REG, t, at);
                 }
                 if (all_double && /* *usedint + */ st->getNumElements() <= 8) {
                     *usedint += st->getNumElements();
-                    // FIXME: needs to be: ArrayType::get(Type::getDoubleTy(*CU->TT->ctx),
-                    // st->getNumElements())
-                    return Argument(C_AGGREGATE_REG, t, t->type);
+                    auto at = ArrayType::get(Type::getDoubleTy(*CU->TT->ctx), st->getNumElements());
+                    return Argument(C_ARRAY_REG, t, at);
                 }
 
                 // Integer or mixed-integer-float case:

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -359,7 +359,7 @@ for _, name in ipairs(all_scalar_names) do
     local ok = check()
     if ok ~= 0 then
       print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
-      error("scalar test failed at N=" .. tostring(N) .. ": error code " .. tostring(ok))
+      error("scalar test failed for N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. ": error code " .. tostring(ok))
     end
   end
 end
@@ -385,7 +385,7 @@ for _, name in ipairs(all_names) do
     local ok = check()
     if ok ~= 0 then
       print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
-      error("one-arg aggregate test failed at N=" .. tostring(N) .. ": error code " .. tostring(ok))
+      error("aggregate test failed for N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. " where " .. tostring(aggtyp) .. "=" .. tostring(aggtyp:getentries():map(function(f) return tostring(f.field) .. "=" .. tostring(f.type) end)) .. ": error code " .. tostring(ok))
     end
   end
 end
@@ -413,7 +413,7 @@ for _, name in ipairs(all_names) do
     local ok = check()
     if ok ~= 0 then
       print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
-      error("two-arg aggregate test failed at N=" .. tostring(N) .. ": error code " .. tostring(ok))
+      error("aggregate test failed for N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. " where " .. tostring(aggtyp) .. "=" .. tostring(aggtyp:getentries():map(function(f) return tostring(f.field) .. "=" .. tostring(f.type) end)) .. ": error code " .. tostring(ok))
     end
   end
 end

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -209,7 +209,7 @@ local function generate_nonuniform_scalar_terra(mod, name, types, N)
   mod[name .. N] = f
 end
 
-local function generate_aggregate_terra(mod, name, aggtyp, N)
+local function generate_aggregate_one_arg_terra(mod, name, aggtyp, N)
   local terra f(x : aggtyp)
     escape
       for i = 1, N do
@@ -242,21 +242,19 @@ for i, type_rotation in ipairs(type_rotations) do
   end
 end
 
-generate_aggregate_terra(t, "tp", c["p0"], 0)
+generate_aggregate_one_arg_terra(t, "tp", c["p0"], 0)
 
 for i, name in ipairs(uniform_names) do
   for N = 1, 9 do
-    generate_aggregate_terra(t, "t" .. name, c[name .. N], N)
+    generate_aggregate_one_arg_terra(t, "t" .. name, c[name .. N], N)
   end
 end
 
 for i, name in ipairs(nonuniform_names) do
   for N = 1, 9 do
-    generate_aggregate_terra(t, "t" .. name, c[name .. N], N)
+    generate_aggregate_one_arg_terra(t, "t" .. name, c[name .. N], N)
   end
 end
-
-local p0 = c.p0
 
 local qs = {c.q1, c.q2, c.q3, c.q4, c.q5, c.q6, c.q7, c.q8, c.q9}
 local cqs = {c.cq1, c.cq2, c.cq3, c.cq4, c.cq5, c.cq6, c.cq7, c.cq8, c.cq9}
@@ -442,13 +440,51 @@ terra part1()
   teq(c.cg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
   teq(t.tg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
 
+  teq(c.ch1(1), 1)
+  teq(t.th1(1), 1)
+  teq(c.ch2(1, 2), 3)
+  teq(t.th2(1, 2), 3)
+  teq(c.ch3(1, 2, 3), 6)
+  teq(t.th3(1, 2, 3), 6)
+  teq(c.ch4(1, 2, 3, 4), 10)
+  teq(t.th4(1, 2, 3, 4), 10)
+  teq(c.ch5(1, 2, 3, 4, 5), 15)
+  teq(t.th5(1, 2, 3, 4, 5), 15)
+  teq(c.ch6(1, 2, 3, 4, 5, 6), 21)
+  teq(t.th6(1, 2, 3, 4, 5, 6), 21)
+  teq(c.ch7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(t.th7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(c.ch8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(t.th8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(c.ch9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  teq(t.th9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+
+  teq(c.ci1(1), 1)
+  teq(t.ti1(1), 1)
+  teq(c.ci2(1, 2), 3)
+  teq(t.ti2(1, 2), 3)
+  teq(c.ci3(1, 2, 3), 6)
+  teq(t.ti3(1, 2, 3), 6)
+  teq(c.ci4(1, 2, 3, 4), 10)
+  teq(t.ti4(1, 2, 3, 4), 10)
+  teq(c.ci5(1, 2, 3, 4, 5), 15)
+  teq(t.ti5(1, 2, 3, 4, 5), 15)
+  teq(c.ci6(1, 2, 3, 4, 5, 6), 21)
+  teq(t.ti6(1, 2, 3, 4, 5, 6), 21)
+  teq(c.ci7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(t.ti7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(c.ci8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(t.ti8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(c.ci9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  teq(t.ti9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+
   return 0
 end
 part1:compile() -- workaround: function at line 620 has more than 60 upvalues
 -- part1:printpretty(false)
 
 terra part2()
-  var x0 : p0
+  var x0 : c.p0
   var cx0 = c.cp0(x0)
   var tx0 = t.tp0(x0)
 

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -9,13 +9,18 @@
 --      * Pass 1..N values as separate arguments to a function, and return the
 --        same type.
 --
+--  * Same, but with fields of a rotating set of types.
+--
 --  * Pass/return an empty struct.
 --
 --  * For each type in {int8, int16, int32, int64, float, double}:
---      * Pass (and return) a struct with 1..N fields of that type.
+--      * Pass (and return) a single struct argument with 1..N fields
+--        of the type above.
 --
---  * Same, but with fields of rotating types (int8, int16, int32, int64,
---    double).
+--  * For each type in {int8, int16, int32, int64, float, double}:
+--      * Pass two struct arguments, as above, and return a struct.
+--
+--  * Same, but with fields of a rotating set of types.
 --
 -- A couple notable features (especially compared to cconv.t):
 --

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -3,35 +3,33 @@
 --
 -- The test covers:
 --
---  * Pass/return void/no arguments.
---
---  * For each type in {int8, int16, int32, int64, float, double}:
---      * Pass 1..N values as separate arguments to a function, and return the
---        same type.
---
---  * Same, but with fields of a rotating set of types.
+--  * Pass no arguments and return void.
 --
 --  * Pass/return an empty struct.
+--
+--  * For each type in {int8, int16, int32, int64, float, double}:
+--      * Pass 1..N scalar arguments of this type, and return the same type.
 --
 --  * For each type in {int8, int16, int32, int64, float, double}:
 --      * Pass (and return) a single struct argument with 1..N fields
 --        of the type above.
 --
 --  * For each type in {int8, int16, int32, int64, float, double}:
---      * Pass two struct arguments, as above, and return a struct.
+--      * Pass two struct arguments, as above, and return same struct.
 --
---  * Same, but with fields of a rotating set of types.
+--  * As each of the three cases above, but with arguments/fields
+--    picked from a rotating set of types.
 --
 -- A couple notable features (especially compared to cconv.t):
 --
---  * The tests verify that structs are passed by value, by modifying the
---    arguments within the called functions.
+--  * The tests verify that structs are passed by value, ensuring
+--    modifications within the callee do not affect the caller.
 --
 --  * As compared to cconv.t, this test verifies that Terra can call both
 --    itself and C. The latter is particularly important for ensuring we match
 --    the ABI of the system C compiler.
 --
---  * As a bonus, the use of C allows quick comparisons between Clang's and
+--  * As a bonus, the use of C enables comparisons between Clang's and
 --    Terra's output. A command to generate the LLVM IR is shown (commented)
 --    at the bottom of the file.
 

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -35,8 +35,10 @@
 
 local test = require("test")
 
+local MAX_N = 12 -- Needs to be <= 22 to avoid overflowing uint8.
+
 local ctypes = {
-  [int8] = "int8_t",
+  [uint8] = "uint8_t",
   [int16] = "int16_t",
   [int32] = "int32_t",
   [int64] = "int64_t",
@@ -109,21 +111,25 @@ local function generate_aggregate_two_arg_function(name, aggname, N)
 end
 
 local uniform_names = terralib.newlist({"q", "r", "s", "t", "u", "v"})
-local types = {int8, int16, int32, int64, float, double}
+local types = {uint8, int16, int32, int64, float, double}
 
 local nonuniform_names = terralib.newlist({"w", "x"})
 local type_rotations = {
-  {int8, int16, int32, int64, double},
-  {float, float, int8, int8, int16, int32, int64},
+  {uint8, int16, int32, int64, double},
+  {float, float, uint8, uint8, int16, int32, int64},
 }
 
 local all_names = terralib.newlist()
 all_names:insertall(uniform_names)
 all_names:insertall(nonuniform_names)
 
-local uniform_scalar_names = {"b", "c", "d", "e", "f", "g"}
+local uniform_scalar_names = terralib.newlist({"b", "c", "d", "e", "f", "g"})
 
-local nonuniform_scalar_names = {"h", "i"}
+local nonuniform_scalar_names = terralib.newlist({"h", "i"})
+
+local all_scalar_names = terralib.newlist()
+all_scalar_names:insertall(uniform_scalar_names)
+all_scalar_names:insertall(nonuniform_scalar_names)
 
 local c
 do
@@ -134,7 +140,7 @@ do
 
   for i, typ in ipairs(types) do
     local name = uniform_names[i]
-    for N = 1, 9 do
+    for N = 1, MAX_N do
       definitions:insert(generate_uniform_struct(name, typ, N))
     end
     definitions:insert("")
@@ -142,7 +148,7 @@ do
 
   for i, type_rotation in ipairs(type_rotations) do
     local name = nonuniform_names[i]
-    for N = 1, 9 do
+    for N = 1, MAX_N do
       definitions:insert(generate_nonuniform_struct(name, type_rotation, N))
     end
     definitions:insert("")
@@ -153,7 +159,7 @@ do
 
   for i, typ in ipairs(types) do
     local name = uniform_scalar_names[i]
-    for N = 1, 9 do
+    for N = 1, MAX_N do
       definitions:insert(generate_uniform_scalar_function("c" .. name, typ, N))
     end
     definitions:insert("")
@@ -161,7 +167,7 @@ do
 
   for i, type_rotation in ipairs(type_rotations) do
     local name = nonuniform_scalar_names[i]
-    for N = 1, 9 do
+    for N = 1, MAX_N do
       definitions:insert(
         generate_nonuniform_scalar_function("c" .. name, type_rotation, N))
     end
@@ -172,7 +178,7 @@ do
   definitions:insert("")
 
   for _, name in ipairs(all_names) do
-    for N = 1, 9 do
+    for N = 1, MAX_N do
       definitions:insert(
         generate_aggregate_one_arg_function("c" .. name, name, N))
     end
@@ -180,7 +186,7 @@ do
   end
 
   for _, name in ipairs(all_names) do
-    for N = 1, 9 do
+    for N = 1, MAX_N do
       definitions:insert(
         generate_aggregate_two_arg_function("c2" .. name, name, N))
     end
@@ -260,14 +266,14 @@ generate_void_terra(t, "ta0")
 
 for i, typ in ipairs(types) do
   local name = uniform_scalar_names[i]
-  for N = 1, 9 do
+  for N = 1, MAX_N do
     generate_uniform_scalar_terra(t, "t" .. name, typ, N)
   end
 end
 
 for i, type_rotation in ipairs(type_rotations) do
   local name = nonuniform_scalar_names[i]
-  for N = 1, 9 do
+  for N = 1, MAX_N do
     generate_nonuniform_scalar_terra(t, "t" .. name, type_rotation, N)
   end
 end
@@ -275,44 +281,16 @@ end
 generate_aggregate_one_arg_terra(t, "tp", c["p0"], 0)
 
 for _, name in ipairs(all_names) do
-  for N = 1, 9 do
+  for N = 1, MAX_N do
     generate_aggregate_one_arg_terra(t, "t" .. name, c[name .. N], N)
   end
 end
 
 for _, name in ipairs(all_names) do
-  for N = 1, 9 do
+  for N = 1, MAX_N do
     generate_aggregate_two_arg_terra(t, "t2" .. name, c[name .. N], N)
   end
 end
-
-local qs = {c.q1, c.q2, c.q3, c.q4, c.q5, c.q6, c.q7, c.q8, c.q9}
-local cqs = {c.cq1, c.cq2, c.cq3, c.cq4, c.cq5, c.cq6, c.cq7, c.cq8, c.cq9}
-local tqs = {t.tq1, t.tq2, t.tq3, t.tq4, t.tq5, t.tq6, t.tq7, t.tq8, t.tq9}
-
-local rs = {c.r1, c.r2, c.r3, c.r4, c.r5, c.r6, c.r7, c.r8, c.r9}
-local crs = {c.cr1, c.cr2, c.cr3, c.cr4, c.cr5, c.cr6, c.cr7, c.cr8, c.cr9}
-local trs = {t.tr1, t.tr2, t.tr3, t.tr4, t.tr5, t.tr6, t.tr7, t.tr8, t.tr9}
-
-local ss = {c.s1, c.s2, c.s3, c.s4, c.s5, c.s6, c.s7, c.s8, c.s9}
-local css = {c.cs1, c.cs2, c.cs3, c.cs4, c.cs5, c.cs6, c.cs7, c.cs8, c.cs9}
-local tss = {t.ts1, t.ts2, t.ts3, t.ts4, t.ts5, t.ts6, t.ts7, t.ts8, t.ts9}
-
-local ts = {c.t1, c.t2, c.t3, c.t4, c.t5, c.t6, c.t7, c.t8, c.t9}
-local cts = {c.ct1, c.ct2, c.ct3, c.ct4, c.ct5, c.ct6, c.ct7, c.ct8, c.ct9}
-local tts = {t.tt1, t.tt2, t.tt3, t.tt4, t.tt5, t.tt6, t.tt7, t.tt8, t.tt9}
-
-local us = {c.u1, c.u2, c.u3, c.u4, c.u5, c.u6, c.u7, c.u8, c.u9}
-local cus = {c.cu1, c.cu2, c.cu3, c.cu4, c.cu5, c.cu6, c.cu7, c.cu8, c.cu9}
-local tus = {t.tu1, t.tu2, t.tu3, t.tu4, t.tu5, t.tu6, t.tu7, t.tu8, t.tu9}
-
-local vs = {c.v1, c.v2, c.v3, c.v4, c.v5, c.v6, c.v7, c.v8, c.v9}
-local cvs = {c.cv1, c.cv2, c.cv3, c.cv4, c.cv5, c.cv6, c.cv7, c.cv8, c.cv9}
-local tvs = {t.tv1, t.tv2, t.tv3, t.tv4, t.tv5, t.tv6, t.tv7, t.tv8, t.tv9}
-
-local ws = {c.w1, c.w2, c.w3, c.w4, c.w5, c.w6, c.w7, c.w8, c.w9}
-local cws = {c.cw1, c.cw2, c.cw3, c.cw4, c.cw5, c.cw6, c.cw7, c.cw8, c.cw9}
-local tws = {t.tw1, t.tw2, t.tw3, t.tw4, t.tw5, t.tw6, t.tw7, t.tw8, t.tw9}
 
 -- Generate a unique exit condition for each test site.
 local exit_condition = 1
@@ -357,157 +335,25 @@ terra part1()
   c.ca0()
   t.ta0()
 
-  teq(c.cb1(1), 1)
-  teq(t.tb1(1), 1)
-  teq(c.cb2(1, 2), 3)
-  teq(t.tb2(1, 2), 3)
-  teq(c.cb3(1, 2, 3), 6)
-  teq(t.tb3(1, 2, 3), 6)
-  teq(c.cb4(1, 2, 3, 4), 10)
-  teq(t.tb4(1, 2, 3, 4), 10)
-  teq(c.cb5(1, 2, 3, 4, 5), 15)
-  teq(t.tb5(1, 2, 3, 4, 5), 15)
-  teq(c.cb6(1, 2, 3, 4, 5, 6), 21)
-  teq(t.tb6(1, 2, 3, 4, 5, 6), 21)
-  teq(c.cb7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(t.tb7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(c.cb8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(t.tb8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(c.cb9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-  teq(t.tb9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-
-  teq(c.cc1(1), 1)
-  teq(t.tc1(1), 1)
-  teq(c.cc2(1, 2), 3)
-  teq(t.tc2(1, 2), 3)
-  teq(c.cc3(1, 2, 3), 6)
-  teq(t.tc3(1, 2, 3), 6)
-  teq(c.cc4(1, 2, 3, 4), 10)
-  teq(t.tc4(1, 2, 3, 4), 10)
-  teq(c.cc5(1, 2, 3, 4, 5), 15)
-  teq(t.tc5(1, 2, 3, 4, 5), 15)
-  teq(c.cc6(1, 2, 3, 4, 5, 6), 21)
-  teq(t.tc6(1, 2, 3, 4, 5, 6), 21)
-  teq(c.cc7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(t.tc7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(c.cc8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(t.tc8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(c.cc9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-  teq(t.tc9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-
-  teq(c.cd1(1), 1)
-  teq(t.td1(1), 1)
-  teq(c.cd2(10, 2), 12)
-  teq(t.td2(10, 2), 12)
-  teq(c.cd3(100, 20, 3), 123)
-  teq(t.td3(100, 20, 3), 123)
-  teq(c.cd4(1000, 200, 30, 4), 1234)
-  teq(t.td4(1000, 200, 30, 4), 1234)
-  teq(c.cd5(10000, 2000, 300, 40, 5), 12345)
-  teq(t.td5(10000, 2000, 300, 40, 5), 12345)
-  teq(c.cd6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(t.td6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(c.cd7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(t.td7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(c.cd8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(t.td8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(c.cd9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(t.td9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-
-  teq(c.ce1(1), 1)
-  teq(t.te1(1), 1)
-  teq(c.ce2(10, 2), 12)
-  teq(t.te2(10, 2), 12)
-  teq(c.ce3(100, 20, 3), 123)
-  teq(t.te3(100, 20, 3), 123)
-  teq(c.ce4(1000, 200, 30, 4), 1234)
-  teq(t.te4(1000, 200, 30, 4), 1234)
-  teq(c.ce5(10000, 2000, 300, 40, 5), 12345)
-  teq(t.te5(10000, 2000, 300, 40, 5), 12345)
-  teq(c.ce6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(t.te6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(c.ce7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(t.te7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(c.ce8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(t.te8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(c.ce9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(t.te9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-
-  teq(c.cf1(1), 1)
-  teq(t.tf1(1), 1)
-  teq(c.cf2(10, 2), 12)
-  teq(t.tf2(10, 2), 12)
-  teq(c.cf3(100, 20, 3), 123)
-  teq(t.tf3(100, 20, 3), 123)
-  teq(c.cf4(1000, 200, 30, 4), 1234)
-  teq(t.tf4(1000, 200, 30, 4), 1234)
-  teq(c.cf5(10000, 2000, 300, 40, 5), 12345)
-  teq(t.tf5(10000, 2000, 300, 40, 5), 12345)
-  teq(c.cf6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(t.tf6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(c.cf7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(t.tf7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(c.cf8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(t.tf8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(c.cf9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(t.tf9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-
-  teq(c.cg1(1), 1)
-  teq(t.tg1(1), 1)
-  teq(c.cg2(10, 2), 12)
-  teq(t.tg2(10, 2), 12)
-  teq(c.cg3(100, 20, 3), 123)
-  teq(t.tg3(100, 20, 3), 123)
-  teq(c.cg4(1000, 200, 30, 4), 1234)
-  teq(t.tg4(1000, 200, 30, 4), 1234)
-  teq(c.cg5(10000, 2000, 300, 40, 5), 12345)
-  teq(t.tg5(10000, 2000, 300, 40, 5), 12345)
-  teq(c.cg6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(t.tg6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(c.cg7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(t.tg7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(c.cg8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(t.tg8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(c.cg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(t.tg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-
-  teq(c.ch1(1), 1)
-  teq(t.th1(1), 1)
-  teq(c.ch2(1, 2), 3)
-  teq(t.th2(1, 2), 3)
-  teq(c.ch3(1, 2, 3), 6)
-  teq(t.th3(1, 2, 3), 6)
-  teq(c.ch4(1, 2, 3, 4), 10)
-  teq(t.th4(1, 2, 3, 4), 10)
-  teq(c.ch5(1, 2, 3, 4, 5), 15)
-  teq(t.th5(1, 2, 3, 4, 5), 15)
-  teq(c.ch6(1, 2, 3, 4, 5, 6), 21)
-  teq(t.th6(1, 2, 3, 4, 5, 6), 21)
-  teq(c.ch7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(t.th7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(c.ch8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(t.th8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(c.ch9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-  teq(t.th9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-
-  teq(c.ci1(1), 1)
-  teq(t.ti1(1), 1)
-  teq(c.ci2(1, 2), 3)
-  teq(t.ti2(1, 2), 3)
-  teq(c.ci3(1, 2, 3), 6)
-  teq(t.ti3(1, 2, 3), 6)
-  teq(c.ci4(1, 2, 3, 4), 10)
-  teq(t.ti4(1, 2, 3, 4), 10)
-  teq(c.ci5(1, 2, 3, 4, 5), 15)
-  teq(t.ti5(1, 2, 3, 4, 5), 15)
-  teq(c.ci6(1, 2, 3, 4, 5, 6), 21)
-  teq(t.ti6(1, 2, 3, 4, 5, 6), 21)
-  teq(c.ci7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(t.ti7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(c.ci8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(t.ti8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(c.ci9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-  teq(t.ti9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  escape
+    for _, name in ipairs(all_scalar_names) do
+      for N = 1, MAX_N do
+        local arglist = terralib.newlist()
+        local expected_result = 0
+        for i = 1, N do
+          arglist:insert(i)
+          expected_result = expected_result + i
+        end
+        assert(expected_result < 255, "value is too large to fit in uint8, not safe to test")
+        local cfunc = c["c" .. name .. N]
+        local tfunc = t["t" .. name .. N]
+        emit quote
+          teq(cfunc(arglist), expected_result)
+          teq(tfunc(arglist), expected_result)
+        end
+      end
+    end
+  end
 
   return 0
 end
@@ -522,10 +368,11 @@ terra part2()
 
   escape
     for _, name in ipairs(all_names) do
-      for N = 1, 9 do
+      for N = 1, MAX_N do
         local aggtyp = c[name .. N]
         local cfunc = c["c" .. name .. N]
         local tfunc = t["t" .. name .. N]
+        assert(11 * N < 255, "value is too large to fit in uint8, not safe to test")
         emit quote
           var x : aggtyp
           init_fields(x, 10, N)
@@ -542,10 +389,11 @@ terra part2()
 
   escape
     for _, name in ipairs(all_names) do
-      for N = 1, 9 do
+      for N = 1, MAX_N do
         local aggtyp = c[name .. N]
         local cfunc = c["c2" .. name .. N]
         local tfunc = t["t2" .. name .. N]
+        assert(11 * N < 255, "value is too large to fit in uint8, not safe to test")
         emit quote
           var x : aggtyp
           init_fields(x, 10, N)

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -32,402 +32,259 @@
 
 local test = require("test")
 
-local c = terralib.includecstring [[
-#include <stdint.h>
+local ctypes = {
+  [int8] = "int8_t",
+  [int16] = "int16_t",
+  [int32] = "int32_t",
+  [int64] = "int64_t",
+  [float] = "float",
+  [double] = "double",
+}
 
-typedef struct p0 {} p0;
+local function generate_uniform_struct(name, typ, N)
+  local parts = terralib.newlist({"typedef struct " .. name .. N .. " {"})
+  for i = 1, N do
+    parts:insert(ctypes[typ] .. " f" .. i .. ";")
+  end
+  parts:insert("} " .. name .. N .. ";")
+  return parts:concat(" ")
+end
 
-typedef struct q1 { int8_t f1; } q1;
-typedef struct q2 { int8_t f1; int8_t f2; } q2;
-typedef struct q3 { int8_t f1; int8_t f2; int8_t f3; } q3;
-typedef struct q4 { int8_t f1; int8_t f2; int8_t f3; int8_t f4; } q4;
-typedef struct q5 { int8_t f1; int8_t f2; int8_t f3; int8_t f4; int8_t f5; } q5;
-typedef struct q6 { int8_t f1; int8_t f2; int8_t f3; int8_t f4; int8_t f5; int8_t f6; } q6;
-typedef struct q7 { int8_t f1; int8_t f2; int8_t f3; int8_t f4; int8_t f5; int8_t f6; int8_t f7; } q7;
-typedef struct q8 { int8_t f1; int8_t f2; int8_t f3; int8_t f4; int8_t f5; int8_t f6; int8_t f7; int8_t f8; } q8;
-typedef struct q9 { int8_t f1; int8_t f2; int8_t f3; int8_t f4; int8_t f5; int8_t f6; int8_t f7; int8_t f8; int8_t f9; } q9;
+local function generate_nonuniform_struct(name, types, N)
+  local parts = terralib.newlist({"typedef struct " .. name .. N .. " {"})
+  for i = 1, N do
+    local typ = types[((i - 1) % #types) + 1]
+    parts:insert(ctypes[typ] .. " f" .. i .. ";")
+  end
+  parts:insert("} " .. name .. N .. ";")
+  return parts:concat(" ")
+end
 
-typedef struct r1 { int16_t f1; } r1;
-typedef struct r2 { int16_t f1; int16_t f2; } r2;
-typedef struct r3 { int16_t f1; int16_t f2; int16_t f3; } r3;
-typedef struct r4 { int16_t f1; int16_t f2; int16_t f3; int16_t f4; } r4;
-typedef struct r5 { int16_t f1; int16_t f2; int16_t f3; int16_t f4; int16_t f5; } r5;
-typedef struct r6 { int16_t f1; int16_t f2; int16_t f3; int16_t f4; int16_t f5; int16_t f6; } r6;
-typedef struct r7 { int16_t f1; int16_t f2; int16_t f3; int16_t f4; int16_t f5; int16_t f6; int16_t f7; } r7;
-typedef struct r8 { int16_t f1; int16_t f2; int16_t f3; int16_t f4; int16_t f5; int16_t f6; int16_t f7; int16_t f8; } r8;
-typedef struct r9 { int16_t f1; int16_t f2; int16_t f3; int16_t f4; int16_t f5; int16_t f6; int16_t f7; int16_t f8; int16_t f9; } r9;
+local function generate_void_function(name)
+  return "void " .. name .. "() {}"
+end
 
-typedef struct s1 { int32_t f1; } s1;
-typedef struct s2 { int32_t f1; int32_t f2; } s2;
-typedef struct s3 { int32_t f1; int32_t f2; int32_t f3; } s3;
-typedef struct s4 { int32_t f1; int32_t f2; int32_t f3; int32_t f4; } s4;
-typedef struct s5 { int32_t f1; int32_t f2; int32_t f3; int32_t f4; int32_t f5; } s5;
-typedef struct s6 { int32_t f1; int32_t f2; int32_t f3; int32_t f4; int32_t f5; int32_t f6; } s6;
-typedef struct s7 { int32_t f1; int32_t f2; int32_t f3; int32_t f4; int32_t f5; int32_t f6; int32_t f7; } s7;
-typedef struct s8 { int32_t f1; int32_t f2; int32_t f3; int32_t f4; int32_t f5; int32_t f6; int32_t f7; int32_t f8; } s8;
-typedef struct s9 { int32_t f1; int32_t f2; int32_t f3; int32_t f4; int32_t f5; int32_t f6; int32_t f7; int32_t f8; int32_t f9; } s9;
+local function generate_uniform_scalar_function(name, typ, N)
+  local arglist = terralib.newlist()
+  for i = 1, N do
+    arglist:insert(ctypes[typ] .. " x" .. i)
+  end
+  local exprlist = terralib.newlist()
+  for i = 1, N do
+    exprlist:insert("x" .. i)
+  end
+  return ctypes[typ] .. " " .. name .. N .. "(" .. arglist:concat(", ") .. ") { return " .. exprlist:concat(" + ") .. "; }"
+end
 
-typedef struct t1 { int64_t f1; } t1;
-typedef struct t2 { int64_t f1; int64_t f2; } t2;
-typedef struct t3 { int64_t f1; int64_t f2; int64_t f3; } t3;
-typedef struct t4 { int64_t f1; int64_t f2; int64_t f3; int64_t f4; } t4;
-typedef struct t5 { int64_t f1; int64_t f2; int64_t f3; int64_t f4; int64_t f5; } t5;
-typedef struct t6 { int64_t f1; int64_t f2; int64_t f3; int64_t f4; int64_t f5; int64_t f6; } t6;
-typedef struct t7 { int64_t f1; int64_t f2; int64_t f3; int64_t f4; int64_t f5; int64_t f6; int64_t f7; } t7;
-typedef struct t8 { int64_t f1; int64_t f2; int64_t f3; int64_t f4; int64_t f5; int64_t f6; int64_t f7; int64_t f8; } t8;
-typedef struct t9 { int64_t f1; int64_t f2; int64_t f3; int64_t f4; int64_t f5; int64_t f6; int64_t f7; int64_t f8; int64_t f9; } t9;
+local function generate_nonuniform_scalar_function(name, types, N)
+  local arglist = terralib.newlist()
+  for i = 1, N do
+    local typ = types[((i - 1) % #types) + 1]
+    arglist:insert(ctypes[typ] .. " x" .. i)
+  end
+  local exprlist = terralib.newlist()
+  for i = 1, N do
+    exprlist:insert("x" .. i)
+  end
+  return "double " .. name .. N .. "(" .. arglist:concat(", ") .. ") { return " .. exprlist:concat(" + ") .. "; }"
+end
 
-typedef struct u1 { float f1; } u1;
-typedef struct u2 { float f1; float f2; } u2;
-typedef struct u3 { float f1; float f2; float f3; } u3;
-typedef struct u4 { float f1; float f2; float f3; float f4; } u4;
-typedef struct u5 { float f1; float f2; float f3; float f4; float f5; } u5;
-typedef struct u6 { float f1; float f2; float f3; float f4; float f5; float f6; } u6;
-typedef struct u7 { float f1; float f2; float f3; float f4; float f5; float f6; float f7; } u7;
-typedef struct u8 { float f1; float f2; float f3; float f4; float f5; float f6; float f7; float f8; } u8;
-typedef struct u9 { float f1; float f2; float f3; float f4; float f5; float f6; float f7; float f8; float f9; } u9;
+local function generate_aggregate_one_arg_function(name, aggname, N)
+  local statlist = terralib.newlist()
+  for i = 1, N do
+    statlist:insert("x.f" .. i .. " += " .. i .. ";")
+  end
+  return aggname .. N .. " " .. name .. N .. "(" .. aggname .. N .. " x) { " .. statlist:concat(" ") .. " return x; }"
+end
 
-typedef struct v1 { double f1; } v1;
-typedef struct v2 { double f1; double f2; } v2;
-typedef struct v3 { double f1; double f2; double f3; } v3;
-typedef struct v4 { double f1; double f2; double f3; double f4; } v4;
-typedef struct v5 { double f1; double f2; double f3; double f4; double f5; } v5;
-typedef struct v6 { double f1; double f2; double f3; double f4; double f5; double f6; } v6;
-typedef struct v7 { double f1; double f2; double f3; double f4; double f5; double f6; double f7; } v7;
-typedef struct v8 { double f1; double f2; double f3; double f4; double f5; double f6; double f7; double f8; } v8;
-typedef struct v9 { double f1; double f2; double f3; double f4; double f5; double f6; double f7; double f8; double f9; } v9;
+local uniform_names = {"q", "r", "s", "t", "u", "v"}
+local types = {int8, int16, int32, int64, float, double}
 
-typedef struct w1 { int8_t f1; } w1;
-typedef struct w2 { int8_t f1; int16_t f2; } w2;
-typedef struct w3 { int8_t f1; int16_t f2; int32_t f3; } w3;
-typedef struct w4 { int8_t f1; int16_t f2; int32_t f3; int64_t f4; } w4;
-typedef struct w5 { int8_t f1; int16_t f2; int32_t f3; int64_t f4; double f5; } w5;
-typedef struct w6 { int8_t f1; int16_t f2; int32_t f3; int64_t f4; double f5; int8_t f6; } w6;
-typedef struct w7 { int8_t f1; int16_t f2; int32_t f3; int64_t f4; double f5; int8_t f6; int16_t f7; } w7;
-typedef struct w8 { int8_t f1; int16_t f2; int32_t f3; int64_t f4; double f5; int8_t f6; int16_t f7; int32_t f8; } w8;
-typedef struct w9 { int8_t f1; int16_t f2; int32_t f3; int64_t f4; double f5; int8_t f6; int16_t f7; int32_t f8; int64_t f9; } w9;
+local nonuniform_names = {"w", "x"}
+local type_rotations = {
+  {int8, int16, int32, int64, double},
+  {float, float, int8, int8, int16, int32, int64},
+}
 
-void ca0() {}
+local uniform_scalar_names = {"b", "c", "d", "e", "f", "g"}
 
-int8_t cb1(int8_t x) { return x + 1; }
-int8_t cb2(int8_t x, int8_t y) { return x + y; }
-int8_t cb3(int8_t x, int8_t y, int8_t z) { return x + y + z; }
-int8_t cb4(int8_t x, int8_t y, int8_t z, int8_t w) { return x + y + z + w; }
-int8_t cb5(int8_t x, int8_t y, int8_t z, int8_t w, int8_t v) { return x + y + z + w + v; }
-int8_t cb6(int8_t x, int8_t y, int8_t z, int8_t w, int8_t v, int8_t u) { return x + y + z + w + v + u; }
-int8_t cb7(int8_t x, int8_t y, int8_t z, int8_t w, int8_t v, int8_t u, int8_t t) { return x + y + z + w + v + u + t; }
-int8_t cb8(int8_t x, int8_t y, int8_t z, int8_t w, int8_t v, int8_t u, int8_t t, int8_t s) { return x + y + z + w + v + u + t + s; }
-int8_t cb9(int8_t x, int8_t y, int8_t z, int8_t w, int8_t v, int8_t u, int8_t t, int8_t s, int8_t r) { return x + y + z + w + v + u + t + s + r; }
+local nonuniform_scalar_names = {"h", "i"}
 
-int16_t cc1(int16_t x) { return x + 1; }
-int16_t cc2(int16_t x, int16_t y) { return x + y; }
-int16_t cc3(int16_t x, int16_t y, int16_t z) { return x + y + z; }
-int16_t cc4(int16_t x, int16_t y, int16_t z, int16_t w) { return x + y + z + w; }
-int16_t cc5(int16_t x, int16_t y, int16_t z, int16_t w, int16_t v) { return x + y + z + w + v; }
-int16_t cc6(int16_t x, int16_t y, int16_t z, int16_t w, int16_t v, int16_t u) { return x + y + z + w + v + u; }
-int16_t cc7(int16_t x, int16_t y, int16_t z, int16_t w, int16_t v, int16_t u, int16_t t) { return x + y + z + w + v + u + t; }
-int16_t cc8(int16_t x, int16_t y, int16_t z, int16_t w, int16_t v, int16_t u, int16_t t, int16_t s) { return x + y + z + w + v + u + t + s; }
-int16_t cc9(int16_t x, int16_t y, int16_t z, int16_t w, int16_t v, int16_t u, int16_t t, int16_t s, int16_t r) { return x + y + z + w + v + u + t + s + r; }
+local c
+do
+  local definitions = terralib.newlist({"#include <stdint.h>", ""})
 
-int32_t cd1(int32_t x) { return x + 1; }
-int32_t cd2(int32_t x, int32_t y) { return x + y; }
-int32_t cd3(int32_t x, int32_t y, int32_t z) { return x + y + z; }
-int32_t cd4(int32_t x, int32_t y, int32_t z, int32_t w) { return x + y + z + w; }
-int32_t cd5(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v) { return x + y + z + w + v; }
-int32_t cd6(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v, int32_t u) { return x + y + z + w + v + u; }
-int32_t cd7(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v, int32_t u, int32_t t) { return x + y + z + w + v + u + t; }
-int32_t cd8(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v, int32_t u, int32_t t, int32_t s) { return x + y + z + w + v + u + t + s; }
-int32_t cd9(int32_t x, int32_t y, int32_t z, int32_t w, int32_t v, int32_t u, int32_t t, int32_t s, int32_t r) { return x + y + z + w + v + u + t + s + r; }
+  definitions:insert(generate_uniform_struct("p", nil, 0))
+  definitions:insert("")
 
-int64_t ce1(int64_t x) { return x + 1; }
-int64_t ce2(int64_t x, int64_t y) { return x + y; }
-int64_t ce3(int64_t x, int64_t y, int64_t z) { return x + y + z; }
-int64_t ce4(int64_t x, int64_t y, int64_t z, int64_t w) { return x + y + z + w; }
-int64_t ce5(int64_t x, int64_t y, int64_t z, int64_t w, int64_t v) { return x + y + z + w + v; }
-int64_t ce6(int64_t x, int64_t y, int64_t z, int64_t w, int64_t v, int64_t u) { return x + y + z + w + v + u; }
-int64_t ce7(int64_t x, int64_t y, int64_t z, int64_t w, int64_t v, int64_t u, int64_t t) { return x + y + z + w + v + u + t; }
-int64_t ce8(int64_t x, int64_t y, int64_t z, int64_t w, int64_t v, int64_t u, int64_t t, int64_t s) { return x + y + z + w + v + u + t + s; }
-int64_t ce9(int64_t x, int64_t y, int64_t z, int64_t w, int64_t v, int64_t u, int64_t t, int64_t s, int64_t r) { return x + y + z + w + v + u + t + s + r; }
+  for i, typ in ipairs(types) do
+    local name = uniform_names[i]
+    for N = 1, 9 do
+      definitions:insert(generate_uniform_struct(name, typ, N))
+    end
+    definitions:insert("")
+  end
 
-float cf1(float x) { return x + 1; }
-float cf2(float x, float y) { return x + y; }
-float cf3(float x, float y, float z) { return x + y + z; }
-float cf4(float x, float y, float z, float w) { return x + y + z + w; }
-float cf5(float x, float y, float z, float w, float v) { return x + y + z + w + v; }
-float cf6(float x, float y, float z, float w, float v, float u) { return x + y + z + w + v + u; }
-float cf7(float x, float y, float z, float w, float v, float u, float t) { return x + y + z + w + v + u + t; }
-float cf8(float x, float y, float z, float w, float v, float u, float t, float s) { return x + y + z + w + v + u + t + s; }
-float cf9(float x, float y, float z, float w, float v, float u, float t, float s, float r) { return x + y + z + w + v + u + t + s + r; }
+  for i, type_rotation in ipairs(type_rotations) do
+    local name = nonuniform_names[i]
+    for N = 1, 9 do
+      definitions:insert(generate_nonuniform_struct(name, type_rotation, N))
+    end
+    definitions:insert("")
+  end
 
-double cg1(double x) { return x + 1; }
-double cg2(double x, double y) { return x + y; }
-double cg3(double x, double y, double z) { return x + y + z; }
-double cg4(double x, double y, double z, double w) { return x + y + z + w; }
-double cg5(double x, double y, double z, double w, double v) { return x + y + z + w + v; }
-double cg6(double x, double y, double z, double w, double v, double u) { return x + y + z + w + v + u; }
-double cg7(double x, double y, double z, double w, double v, double u, double t) { return x + y + z + w + v + u + t; }
-double cg8(double x, double y, double z, double w, double v, double u, double t, double s) { return x + y + z + w + v + u + t + s; }
-double cg9(double x, double y, double z, double w, double v, double u, double t, double s, double r) { return x + y + z + w + v + u + t + s + r; }
+  definitions:insert(generate_void_function("ca0"))
+  definitions:insert("")
 
-p0 cp0(p0 x) { return x; }
+  for i, typ in ipairs(types) do
+    local name = uniform_scalar_names[i]
+    for N = 1, 9 do
+      definitions:insert(generate_uniform_scalar_function("c" .. name, typ, N))
+    end
+    definitions:insert("")
+  end
 
-q1 cq1(q1 x) { x.f1 += 1; return x; }
-q2 cq2(q2 x) { x.f1 += 1; x.f2 += 2; return x; }
-q3 cq3(q3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-q4 cq4(q4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-q5 cq5(q5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-q6 cq6(q6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-q7 cq7(q7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-q8 cq8(q8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-q9 cq9(q9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+  for i, type_rotation in ipairs(type_rotations) do
+    local name = nonuniform_scalar_names[i]
+    for N = 1, 9 do
+      definitions:insert(
+        generate_nonuniform_scalar_function("c" .. name, type_rotation, N))
+    end
+    definitions:insert("")
+  end
 
-r1 cr1(r1 x) { x.f1 += 1; return x; }
-r2 cr2(r2 x) { x.f1 += 1; x.f2 += 2; return x; }
-r3 cr3(r3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-r4 cr4(r4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-r5 cr5(r5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-r6 cr6(r6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-r7 cr7(r7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-r8 cr8(r8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-r9 cr9(r9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+  definitions:insert(generate_aggregate_one_arg_function("cp", "p", 0))
+  definitions:insert("")
 
-s1 cs1(s1 x) { x.f1 += 1; return x; }
-s2 cs2(s2 x) { x.f1 += 1; x.f2 += 2; return x; }
-s3 cs3(s3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-s4 cs4(s4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-s5 cs5(s5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-s6 cs6(s6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-s7 cs7(s7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-s8 cs8(s8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-s9 cs9(s9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+  for i, name in ipairs(uniform_names) do
+    for N = 1, 9 do
+      definitions:insert(
+        generate_aggregate_one_arg_function("c" .. name, name, N))
+    end
+    definitions:insert("")
+  end
 
-t1 ct1(t1 x) { x.f1 += 1; return x; }
-t2 ct2(t2 x) { x.f1 += 1; x.f2 += 2; return x; }
-t3 ct3(t3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-t4 ct4(t4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-t5 ct5(t5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-t6 ct6(t6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-t7 ct7(t7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-t8 ct8(t8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-t9 ct9(t9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+  for i, name in ipairs(nonuniform_names) do
+    for N = 1, 9 do
+      definitions:insert(
+        generate_aggregate_one_arg_function("c" .. name, name, N))
+    end
+    definitions:insert("")
+  end
 
-u1 cu1(u1 x) { x.f1 += 1; return x; }
-u2 cu2(u2 x) { x.f1 += 1; x.f2 += 2; return x; }
-u3 cu3(u3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-u4 cu4(u4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-u5 cu5(u5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-u6 cu6(u6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-u7 cu7(u7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-u8 cu8(u8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-u9 cu9(u9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+  c = terralib.includecstring(definitions:concat("\n"))
+end
 
-v1 cv1(v1 x) { x.f1 += 1; return x; }
-v2 cv2(v2 x) { x.f1 += 1; x.f2 += 2; return x; }
-v3 cv3(v3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-v4 cv4(v4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-v5 cv5(v5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-v6 cv6(v6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-v7 cv7(v7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-v8 cv8(v8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-v9 cv9(v9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+local function generate_void_terra(mod, name)
+  local terra f() end
+  f:setname(name)
+  f:setinlined(false)
+  mod[name] = f
+end
 
-w1 cw1(w1 x) { x.f1 += 1; return x; }
-w2 cw2(w2 x) { x.f1 += 1; x.f2 += 2; return x; }
-w3 cw3(w3 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; return x; }
-w4 cw4(w4 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; return x; }
-w5 cw5(w5 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; return x; }
-w6 cw6(w6 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; return x; }
-w7 cw7(w7 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; return x; }
-w8 cw8(w8 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; return x; }
-w9 cw9(w9 x) { x.f1 += 1; x.f2 += 2; x.f3 += 3; x.f4 += 4; x.f5 += 5; x.f6 += 6; x.f7 += 7; x.f8 += 8; x.f9 += 9; return x; }
+local function generate_uniform_scalar_terra(mod, name, typ, N)
+  local args = terralib.newlist()
+  for i = 1, N do
+    args:insert(terralib.newsymbol(typ, "x" .. i))
+  end
+  local terra f([args])
+    return [args:reduce(function(x, y) return `x + y end)]
+  end
+  f:setname(name .. N)
+  f:setinlined(false)
+  mod[name .. N] = f
+end
 
-]]
+local function generate_nonuniform_scalar_terra(mod, name, types, N)
+  local args = terralib.newlist()
+  for i = 1, N do
+    local typ = types[((i - 1) % #types) + 1]
+    args:insert(terralib.newsymbol(typ, "x" .. i))
+  end
+  local terra f([args])
+    return [args:reduce(function(x, y) return `x + y end)]
+  end
+  f:setname(name .. N)
+  f:setinlined(false)
+  mod[name .. N] = f
+end
 
-local ca0 = c.ca0
-local cb1, cb2, cb3, cb4, cb5, cb6, cb7, cb8, cb9 = c.cb1, c.cb2, c.cb3, c.cb4, c.cb5, c.cb6, c.cb7, c.cb8, c.cb9
-local cc1, cc2, cc3, cc4, cc5, cc6, cc7, cc8, cc9 = c.cc1, c.cc2, c.cc3, c.cc4, c.cc5, c.cc6, c.cc7, c.cc8, c.cc9
-local cd1, cd2, cd3, cd4, cd5, cd6, cd7, cd8, cd9 = c.cd1, c.cd2, c.cd3, c.cd4, c.cd5, c.cd6, c.cd7, c.cd8, c.cd9
-local ce1, ce2, ce3, ce4, ce5, ce6, ce7, ce8, ce9 = c.ce1, c.ce2, c.ce3, c.ce4, c.ce5, c.ce6, c.ce7, c.ce8, c.ce9
-local cf1, cf2, cf3, cf4, cf5, cf6, cf7, cf8, cf9 = c.cf1, c.cf2, c.cf3, c.cf4, c.cf5, c.cf6, c.cf7, c.cf8, c.cf9
-local cg1, cg2, cg3, cg4, cg5, cg6, cg7, cg8, cg9 = c.cg1, c.cg2, c.cg3, c.cg4, c.cg5, c.cg6, c.cg7, c.cg8, c.cg9
+local function generate_aggregate_terra(mod, name, aggtyp, N)
+  local terra f(x : aggtyp)
+    escape
+      for i = 1, N do
+        local field = "f" .. i
+        emit quote x.[field] = x.[field] + i end
+      end
+    end
+    return x
+  end
+  f:setname(name .. N)
+  f:setinlined(false)
+  mod[name .. N] = f
+end
 
-terra ta0() end
+local t = {}
 
-terra tb1(x : int8) return x + 1 end
-terra tb2(x : int8, y : int8) return x + y end
-terra tb3(x : int8, y : int8, z : int8) return x + y + z end
-terra tb4(x : int8, y : int8, z : int8, w : int8) return x + y + z + w end
-terra tb5(x : int8, y : int8, z : int8, w : int8, v : int8) return x + y + z + w + v end
-terra tb6(x : int8, y : int8, z : int8, w : int8, v : int8, u : int8) return x + y + z + w + v + u end
-terra tb7(x : int8, y : int8, z : int8, w : int8, v : int8, u : int8, t : int8) return x + y + z + w + v + u + t end
-terra tb8(x : int8, y : int8, z : int8, w : int8, v : int8, u : int8, t : int8, s : int8) return x + y + z + w + v + u + t + s end
-terra tb9(x : int8, y : int8, z : int8, w : int8, v : int8, u : int8, t : int8, s : int8, r : int8) return x + y + z + w + v + u + t + s + r end
+generate_void_terra(t, "ta0")
 
-terra tc1(x : int16) return x + 1 end
-terra tc2(x : int16, y : int16) return x + y end
-terra tc3(x : int16, y : int16, z : int16) return x + y + z end
-terra tc4(x : int16, y : int16, z : int16, w : int16) return x + y + z + w end
-terra tc5(x : int16, y : int16, z : int16, w : int16, v : int16) return x + y + z + w + v end
-terra tc6(x : int16, y : int16, z : int16, w : int16, v : int16, u : int16) return x + y + z + w + v + u end
-terra tc7(x : int16, y : int16, z : int16, w : int16, v : int16, u : int16, t : int16) return x + y + z + w + v + u + t end
-terra tc8(x : int16, y : int16, z : int16, w : int16, v : int16, u : int16, t : int16, s : int16) return x + y + z + w + v + u + t + s end
-terra tc9(x : int16, y : int16, z : int16, w : int16, v : int16, u : int16, t : int16, s : int16, r : int16) return x + y + z + w + v + u + t + s + r end
+for i, typ in ipairs(types) do
+  local name = uniform_scalar_names[i]
+  for N = 1, 9 do
+    generate_uniform_scalar_terra(t, "t" .. name, typ, N)
+  end
+end
 
-terra td1(x : int32) return x + 1 end
-terra td2(x : int32, y : int32) return x + y end
-terra td3(x : int32, y : int32, z : int32) return x + y + z end
-terra td4(x : int32, y : int32, z : int32, w : int32) return x + y + z + w end
-terra td5(x : int32, y : int32, z : int32, w : int32, v : int32) return x + y + z + w + v end
-terra td6(x : int32, y : int32, z : int32, w : int32, v : int32, u : int32) return x + y + z + w + v + u end
-terra td7(x : int32, y : int32, z : int32, w : int32, v : int32, u : int32, t : int32) return x + y + z + w + v + u + t end
-terra td8(x : int32, y : int32, z : int32, w : int32, v : int32, u : int32, t : int32, s : int32) return x + y + z + w + v + u + t + s end
-terra td9(x : int32, y : int32, z : int32, w : int32, v : int32, u : int32, t : int32, s : int32, r : int32) return x + y + z + w + v + u + t + s + r end
+for i, type_rotation in ipairs(type_rotations) do
+  local name = nonuniform_scalar_names[i]
+  for N = 1, 9 do
+    generate_nonuniform_scalar_terra(t, "t" .. name, type_rotation, N)
+  end
+end
 
-terra te1(x : int64) return x + 1 end
-terra te2(x : int64, y : int64) return x + y end
-terra te3(x : int64, y : int64, z : int64) return x + y + z end
-terra te4(x : int64, y : int64, z : int64, w : int64) return x + y + z + w end
-terra te5(x : int64, y : int64, z : int64, w : int64, v : int64) return x + y + z + w + v end
-terra te6(x : int64, y : int64, z : int64, w : int64, v : int64, u : int64) return x + y + z + w + v + u end
-terra te7(x : int64, y : int64, z : int64, w : int64, v : int64, u : int64, t : int64) return x + y + z + w + v + u + t end
-terra te8(x : int64, y : int64, z : int64, w : int64, v : int64, u : int64, t : int64, s : int64) return x + y + z + w + v + u + t + s end
-terra te9(x : int64, y : int64, z : int64, w : int64, v : int64, u : int64, t : int64, s : int64, r : int64) return x + y + z + w + v + u + t + s + r end
+generate_aggregate_terra(t, "tp", c["p0"], 0)
 
-terra tf1(x : float) return x + 1 end
-terra tf2(x : float, y : float) return x + y end
-terra tf3(x : float, y : float, z : float) return x + y + z end
-terra tf4(x : float, y : float, z : float, w : float) return x + y + z + w end
-terra tf5(x : float, y : float, z : float, w : float, v : float) return x + y + z + w + v end
-terra tf6(x : float, y : float, z : float, w : float, v : float, u : float) return x + y + z + w + v + u end
-terra tf7(x : float, y : float, z : float, w : float, v : float, u : float, t : float) return x + y + z + w + v + u + t end
-terra tf8(x : float, y : float, z : float, w : float, v : float, u : float, t : float, s : float) return x + y + z + w + v + u + t + s end
-terra tf9(x : float, y : float, z : float, w : float, v : float, u : float, t : float, s : float, r : float) return x + y + z + w + v + u + t + s + r end
+for i, name in ipairs(uniform_names) do
+  for N = 1, 9 do
+    generate_aggregate_terra(t, "t" .. name, c[name .. N], N)
+  end
+end
 
-terra tg1(x : double) return x + 1 end
-terra tg2(x : double, y : double) return x + y end
-terra tg3(x : double, y : double, z : double) return x + y + z end
-terra tg4(x : double, y : double, z : double, w : double) return x + y + z + w end
-terra tg5(x : double, y : double, z : double, w : double, v : double) return x + y + z + w + v end
-terra tg6(x : double, y : double, z : double, w : double, v : double, u : double) return x + y + z + w + v + u end
-terra tg7(x : double, y : double, z : double, w : double, v : double, u : double, t : double) return x + y + z + w + v + u + t end
-terra tg8(x : double, y : double, z : double, w : double, v : double, u : double, t : double, s : double) return x + y + z + w + v + u + t + s end
-terra tg9(x : double, y : double, z : double, w : double, v : double, u : double, t : double, s : double, r : double) return x + y + z + w + v + u + t + s + r end
+for i, name in ipairs(nonuniform_names) do
+  for N = 1, 9 do
+    generate_aggregate_terra(t, "t" .. name, c[name .. N], N)
+  end
+end
 
 local p0 = c.p0
 
-terra tp0(x : p0) return x; end
-
-local q1, q2, q3, q4, q5, q6, q7, q8, q9 = c.q1, c.q2, c.q3, c.q4, c.q5, c.q6, c.q7, c.q8, c.q9
-
-terra tq1(x : q1) x.f1 = x.f1 + 1; return x; end
-terra tq2(x : q2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra tq3(x : q3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra tq4(x : q4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra tq5(x : q5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra tq6(x : q6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra tq7(x : q7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra tq8(x : q8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra tq9(x : q9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local r1, r2, r3, r4, r5, r6, r7, r8, r9 = c.r1, c.r2, c.r3, c.r4, c.r5, c.r6, c.r7, c.r8, c.r9
-
-terra tr1(x : r1) x.f1 = x.f1 + 1; return x; end
-terra tr2(x : r2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra tr3(x : r3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra tr4(x : r4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra tr5(x : r5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra tr6(x : r6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra tr7(x : r7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra tr8(x : r8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra tr9(x : r9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local s1, s2, s3, s4, s5, s6, s7, s8, s9 = c.s1, c.s2, c.s3, c.s4, c.s5, c.s6, c.s7, c.s8, c.s9
-
-terra ts1(x : s1) x.f1 = x.f1 + 1; return x; end
-terra ts2(x : s2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra ts3(x : s3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra ts4(x : s4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra ts5(x : s5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra ts6(x : s6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra ts7(x : s7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra ts8(x : s8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra ts9(x : s9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local t1, t2, t3, t4, t5, t6, t7, t8, t9 = c.t1, c.t2, c.t3, c.t4, c.t5, c.t6, c.t7, c.t8, c.t9
-
-terra tt1(x : t1) x.f1 = x.f1 + 1; return x; end
-terra tt2(x : t2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra tt3(x : t3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra tt4(x : t4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra tt5(x : t5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra tt6(x : t6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra tt7(x : t7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra tt8(x : t8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra tt9(x : t9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local u1, u2, u3, u4, u5, u6, u7, u8, u9 = c.u1, c.u2, c.u3, c.u4, c.u5, c.u6, c.u7, c.u8, c.u9
-
-terra tu1(x : u1) x.f1 = x.f1 + 1; return x; end
-terra tu2(x : u2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra tu3(x : u3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra tu4(x : u4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra tu5(x : u5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra tu6(x : u6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra tu7(x : u7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra tu8(x : u8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra tu9(x : u9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local v1, v2, v3, v4, v5, v6, v7, v8, v9 = c.v1, c.v2, c.v3, c.v4, c.v5, c.v6, c.v7, c.v8, c.v9
-
-terra tv1(x : v1) x.f1 = x.f1 + 1; return x; end
-terra tv2(x : v2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra tv3(x : v3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra tv4(x : v4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra tv5(x : v5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra tv6(x : v6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra tv7(x : v7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra tv8(x : v8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra tv9(x : v9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local w1, w2, w3, w4, w5, w6, w7, w8, w9 = c.w1, c.w2, c.w3, c.w4, c.w5, c.w6, c.w7, c.w8, c.w9
-
-terra tw1(x : w1) x.f1 = x.f1 + 1; return x; end
-terra tw2(x : w2) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; return x; end
-terra tw3(x : w3) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; return x; end
-terra tw4(x : w4) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; return x; end
-terra tw5(x : w5) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; return x; end
-terra tw6(x : w6) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; return x; end
-terra tw7(x : w7) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; return x; end
-terra tw8(x : w8) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; return x; end
-terra tw9(x : w9) x.f1 = x.f1 + 1; x.f2 = x.f2 + 2; x.f3 = x.f3 + 3; x.f4 = x.f4 + 4; x.f5 = x.f5 + 5; x.f6 = x.f6 + 6; x.f7 = x.f7 + 7; x.f8 = x.f8 + 8; x.f9 = x.f9 + 9; return x; end
-
-local qs = {q1, q2, q3, q4, q5, q6, q7, q8, q9}
+local qs = {c.q1, c.q2, c.q3, c.q4, c.q5, c.q6, c.q7, c.q8, c.q9}
 local cqs = {c.cq1, c.cq2, c.cq3, c.cq4, c.cq5, c.cq6, c.cq7, c.cq8, c.cq9}
-local tqs = {tq1, tq2, tq3, tq4, tq5, tq6, tq7, tq8, tq9}
+local tqs = {t.tq1, t.tq2, t.tq3, t.tq4, t.tq5, t.tq6, t.tq7, t.tq8, t.tq9}
 
-local rs = {r1, r2, r3, r4, r5, r6, r7, r8, r9}
+local rs = {c.r1, c.r2, c.r3, c.r4, c.r5, c.r6, c.r7, c.r8, c.r9}
 local crs = {c.cr1, c.cr2, c.cr3, c.cr4, c.cr5, c.cr6, c.cr7, c.cr8, c.cr9}
-local trs = {tr1, tr2, tr3, tr4, tr5, tr6, tr7, tr8, tr9}
+local trs = {t.tr1, t.tr2, t.tr3, t.tr4, t.tr5, t.tr6, t.tr7, t.tr8, t.tr9}
 
-local ss = {s1, s2, s3, s4, s5, s6, s7, s8, s9}
+local ss = {c.s1, c.s2, c.s3, c.s4, c.s5, c.s6, c.s7, c.s8, c.s9}
 local css = {c.cs1, c.cs2, c.cs3, c.cs4, c.cs5, c.cs6, c.cs7, c.cs8, c.cs9}
-local tss = {ts1, ts2, ts3, ts4, ts5, ts6, ts7, ts8, ts9}
+local tss = {t.ts1, t.ts2, t.ts3, t.ts4, t.ts5, t.ts6, t.ts7, t.ts8, t.ts9}
 
-local ts = {t1, t2, t3, t4, t5, t6, t7, t8, t9}
+local ts = {c.t1, c.t2, c.t3, c.t4, c.t5, c.t6, c.t7, c.t8, c.t9}
 local cts = {c.ct1, c.ct2, c.ct3, c.ct4, c.ct5, c.ct6, c.ct7, c.ct8, c.ct9}
-local tts = {tt1, tt2, tt3, tt4, tt5, tt6, tt7, tt8, tt9}
+local tts = {t.tt1, t.tt2, t.tt3, t.tt4, t.tt5, t.tt6, t.tt7, t.tt8, t.tt9}
 
-local us = {u1, u2, u3, u4, u5, u6, u7, u8, u9}
+local us = {c.u1, c.u2, c.u3, c.u4, c.u5, c.u6, c.u7, c.u8, c.u9}
 local cus = {c.cu1, c.cu2, c.cu3, c.cu4, c.cu5, c.cu6, c.cu7, c.cu8, c.cu9}
-local tus = {tu1, tu2, tu3, tu4, tu5, tu6, tu7, tu8, tu9}
+local tus = {t.tu1, t.tu2, t.tu3, t.tu4, t.tu5, t.tu6, t.tu7, t.tu8, t.tu9}
 
-local vs = {v1, v2, v3, v4, v5, v6, v7, v8, v9}
+local vs = {c.v1, c.v2, c.v3, c.v4, c.v5, c.v6, c.v7, c.v8, c.v9}
 local cvs = {c.cv1, c.cv2, c.cv3, c.cv4, c.cv5, c.cv6, c.cv7, c.cv8, c.cv9}
-local tvs = {tv1, tv2, tv3, tv4, tv5, tv6, tv7, tv8, tv9}
+local tvs = {t.tv1, t.tv2, t.tv3, t.tv4, t.tv5, t.tv6, t.tv7, t.tv8, t.tv9}
 
-local ws = {w1, w2, w3, w4, w5, w6, w7, w8, w9}
+local ws = {c.w1, c.w2, c.w3, c.w4, c.w5, c.w6, c.w7, c.w8, c.w9}
 local cws = {c.cw1, c.cw2, c.cw3, c.cw4, c.cw5, c.cw6, c.cw7, c.cw8, c.cw9}
-local tws = {tw1, tw2, tw3, tw4, tw5, tw6, tw7, tw8, tw9}
+local tws = {t.tw1, t.tw2, t.tw3, t.tw4, t.tw5, t.tw6, t.tw7, t.tw8, t.tw9}
 
 -- Generate a unique exit condition for each test site.
 local exit_condition = 1
@@ -468,122 +325,122 @@ local check_fields = macro(
   end)
 
 terra part1()
-  ca0()
-  ta0()
+  c.ca0()
+  t.ta0()
 
-  teq(cb1(1), 2)
-  teq(tb1(1), 2)
-  teq(cb2(1, 2), 3)
-  teq(tb2(1, 2), 3)
-  teq(cb3(1, 2, 3), 6)
-  teq(tb3(1, 2, 3), 6)
-  teq(cb4(1, 2, 3, 4), 10)
-  teq(tb4(1, 2, 3, 4), 10)
-  teq(cb5(1, 2, 3, 4, 5), 15)
-  teq(tb5(1, 2, 3, 4, 5), 15)
-  teq(cb6(1, 2, 3, 4, 5, 6), 21)
-  teq(tb6(1, 2, 3, 4, 5, 6), 21)
-  teq(cb7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(tb7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(cb8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(tb8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(cb9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-  teq(tb9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  teq(c.cb1(1), 1)
+  teq(t.tb1(1), 1)
+  teq(c.cb2(1, 2), 3)
+  teq(t.tb2(1, 2), 3)
+  teq(c.cb3(1, 2, 3), 6)
+  teq(t.tb3(1, 2, 3), 6)
+  teq(c.cb4(1, 2, 3, 4), 10)
+  teq(t.tb4(1, 2, 3, 4), 10)
+  teq(c.cb5(1, 2, 3, 4, 5), 15)
+  teq(t.tb5(1, 2, 3, 4, 5), 15)
+  teq(c.cb6(1, 2, 3, 4, 5, 6), 21)
+  teq(t.tb6(1, 2, 3, 4, 5, 6), 21)
+  teq(c.cb7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(t.tb7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(c.cb8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(t.tb8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(c.cb9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  teq(t.tb9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
 
-  teq(cc1(1), 2)
-  teq(tc1(1), 2)
-  teq(cc2(1, 2), 3)
-  teq(tc2(1, 2), 3)
-  teq(cc3(1, 2, 3), 6)
-  teq(tc3(1, 2, 3), 6)
-  teq(cc4(1, 2, 3, 4), 10)
-  teq(tc4(1, 2, 3, 4), 10)
-  teq(cc5(1, 2, 3, 4, 5), 15)
-  teq(tc5(1, 2, 3, 4, 5), 15)
-  teq(cc6(1, 2, 3, 4, 5, 6), 21)
-  teq(tc6(1, 2, 3, 4, 5, 6), 21)
-  teq(cc7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(tc7(1, 2, 3, 4, 5, 6, 7), 28)
-  teq(cc8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(tc8(1, 2, 3, 4, 5, 6, 7, 8), 36)
-  teq(cc9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
-  teq(tc9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  teq(c.cc1(1), 1)
+  teq(t.tc1(1), 1)
+  teq(c.cc2(1, 2), 3)
+  teq(t.tc2(1, 2), 3)
+  teq(c.cc3(1, 2, 3), 6)
+  teq(t.tc3(1, 2, 3), 6)
+  teq(c.cc4(1, 2, 3, 4), 10)
+  teq(t.tc4(1, 2, 3, 4), 10)
+  teq(c.cc5(1, 2, 3, 4, 5), 15)
+  teq(t.tc5(1, 2, 3, 4, 5), 15)
+  teq(c.cc6(1, 2, 3, 4, 5, 6), 21)
+  teq(t.tc6(1, 2, 3, 4, 5, 6), 21)
+  teq(c.cc7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(t.tc7(1, 2, 3, 4, 5, 6, 7), 28)
+  teq(c.cc8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(t.tc8(1, 2, 3, 4, 5, 6, 7, 8), 36)
+  teq(c.cc9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
+  teq(t.tc9(1, 2, 3, 4, 5, 6, 7, 8, 9), 45)
 
-  teq(cd1(1), 2)
-  teq(td1(1), 2)
-  teq(cd2(10, 2), 12)
-  teq(td2(10, 2), 12)
-  teq(cd3(100, 20, 3), 123)
-  teq(td3(100, 20, 3), 123)
-  teq(cd4(1000, 200, 30, 4), 1234)
-  teq(td4(1000, 200, 30, 4), 1234)
-  teq(cd5(10000, 2000, 300, 40, 5), 12345)
-  teq(td5(10000, 2000, 300, 40, 5), 12345)
-  teq(cd6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(td6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(cd7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(td7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(cd8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(td8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(cd9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(td9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(c.cd1(1), 1)
+  teq(t.td1(1), 1)
+  teq(c.cd2(10, 2), 12)
+  teq(t.td2(10, 2), 12)
+  teq(c.cd3(100, 20, 3), 123)
+  teq(t.td3(100, 20, 3), 123)
+  teq(c.cd4(1000, 200, 30, 4), 1234)
+  teq(t.td4(1000, 200, 30, 4), 1234)
+  teq(c.cd5(10000, 2000, 300, 40, 5), 12345)
+  teq(t.td5(10000, 2000, 300, 40, 5), 12345)
+  teq(c.cd6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(t.td6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(c.cd7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(t.td7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(c.cd8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(t.td8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(c.cd9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(t.td9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
 
-  teq(ce1(1), 2)
-  teq(te1(1), 2)
-  teq(ce2(10, 2), 12)
-  teq(te2(10, 2), 12)
-  teq(ce3(100, 20, 3), 123)
-  teq(te3(100, 20, 3), 123)
-  teq(ce4(1000, 200, 30, 4), 1234)
-  teq(te4(1000, 200, 30, 4), 1234)
-  teq(ce5(10000, 2000, 300, 40, 5), 12345)
-  teq(te5(10000, 2000, 300, 40, 5), 12345)
-  teq(ce6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(te6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(ce7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(te7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(ce8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(te8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(ce9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(te9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(c.ce1(1), 1)
+  teq(t.te1(1), 1)
+  teq(c.ce2(10, 2), 12)
+  teq(t.te2(10, 2), 12)
+  teq(c.ce3(100, 20, 3), 123)
+  teq(t.te3(100, 20, 3), 123)
+  teq(c.ce4(1000, 200, 30, 4), 1234)
+  teq(t.te4(1000, 200, 30, 4), 1234)
+  teq(c.ce5(10000, 2000, 300, 40, 5), 12345)
+  teq(t.te5(10000, 2000, 300, 40, 5), 12345)
+  teq(c.ce6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(t.te6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(c.ce7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(t.te7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(c.ce8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(t.te8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(c.ce9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(t.te9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
 
-  teq(cf1(1), 2)
-  teq(tf1(1), 2)
-  teq(cf2(10, 2), 12)
-  teq(tf2(10, 2), 12)
-  teq(cf3(100, 20, 3), 123)
-  teq(tf3(100, 20, 3), 123)
-  teq(cf4(1000, 200, 30, 4), 1234)
-  teq(tf4(1000, 200, 30, 4), 1234)
-  teq(cf5(10000, 2000, 300, 40, 5), 12345)
-  teq(tf5(10000, 2000, 300, 40, 5), 12345)
-  teq(cf6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(tf6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(cf7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(tf7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(cf8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(tf8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(cf9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(tf9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(c.cf1(1), 1)
+  teq(t.tf1(1), 1)
+  teq(c.cf2(10, 2), 12)
+  teq(t.tf2(10, 2), 12)
+  teq(c.cf3(100, 20, 3), 123)
+  teq(t.tf3(100, 20, 3), 123)
+  teq(c.cf4(1000, 200, 30, 4), 1234)
+  teq(t.tf4(1000, 200, 30, 4), 1234)
+  teq(c.cf5(10000, 2000, 300, 40, 5), 12345)
+  teq(t.tf5(10000, 2000, 300, 40, 5), 12345)
+  teq(c.cf6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(t.tf6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(c.cf7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(t.tf7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(c.cf8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(t.tf8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(c.cf9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(t.tf9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
 
-  teq(cg1(1), 2)
-  teq(tg1(1), 2)
-  teq(cg2(10, 2), 12)
-  teq(tg2(10, 2), 12)
-  teq(cg3(100, 20, 3), 123)
-  teq(tg3(100, 20, 3), 123)
-  teq(cg4(1000, 200, 30, 4), 1234)
-  teq(tg4(1000, 200, 30, 4), 1234)
-  teq(cg5(10000, 2000, 300, 40, 5), 12345)
-  teq(tg5(10000, 2000, 300, 40, 5), 12345)
-  teq(cg6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(tg6(100000, 20000, 3000, 400, 50, 6), 123456)
-  teq(cg7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(tg7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
-  teq(cg8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(tg8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
-  teq(cg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
-  teq(tg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(c.cg1(1), 1)
+  teq(t.tg1(1), 1)
+  teq(c.cg2(10, 2), 12)
+  teq(t.tg2(10, 2), 12)
+  teq(c.cg3(100, 20, 3), 123)
+  teq(t.tg3(100, 20, 3), 123)
+  teq(c.cg4(1000, 200, 30, 4), 1234)
+  teq(t.tg4(1000, 200, 30, 4), 1234)
+  teq(c.cg5(10000, 2000, 300, 40, 5), 12345)
+  teq(t.tg5(10000, 2000, 300, 40, 5), 12345)
+  teq(c.cg6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(t.tg6(100000, 20000, 3000, 400, 50, 6), 123456)
+  teq(c.cg7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(t.tg7(1000000, 200000, 30000, 4000, 500, 60, 7), 1234567)
+  teq(c.cg8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(t.tg8(10000000, 2000000, 300000, 40000, 5000, 600, 70, 8), 12345678)
+  teq(c.cg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
+  teq(t.tg9(100000000, 20000000, 3000000, 400000, 50000, 6000, 700, 80, 9), 123456789)
 
   return 0
 end
@@ -593,7 +450,7 @@ part1:compile() -- workaround: function at line 620 has more than 60 upvalues
 terra part2()
   var x0 : p0
   var cx0 = c.cp0(x0)
-  var tx0 = tp0(x0)
+  var tx0 = t.tp0(x0)
 
   escape
     for i, qi in ipairs(qs) do

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -199,12 +199,12 @@ end
 
 local base_types = {uint8, int16, int32, int64, float, double}
 
-local uniform_names = terralib.newlist({"q", "r", "s", "t", "u", "v",
-                                        "qq", "rr", "ss", "tt", "uu", "vv"})
+local uniform_names = terralib.newlist({"p", "q", "r", "s", "t", "u",
+                                        "pp", "qq", "rr", "ss", "tt", "uu"})
 local types = {uint8, int16, int32, int64, float, double,
                uint8[2], int16[2], int32[2], int64[2], float[2], double[2]}
 
-local nonuniform_names = terralib.newlist({"w", "x", "y", "z", "zz"})
+local nonuniform_names = terralib.newlist({"v", "w", "x", "y", "z"})
 local type_rotations = {
   {uint8, int16, int32, int64, double},
   {float, float, uint8, uint8, int16, int32, int64},

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -33,7 +33,8 @@
 --    Terra's output. A command to generate the LLVM IR is shown (commented)
 --    at the bottom of the file.
 
-local MAX_N = 12 -- Needs to be <= 22 to avoid overflowing uint8.
+local MAX_ARRAY_N = 4
+local MAX_N = 9 -- Needs to be <= 22 to avoid overflowing uint8.
 
 local ctypes = {
   [uint8] = "uint8_t",
@@ -44,10 +45,48 @@ local ctypes = {
   [double] = "double",
 }
 
+local function lookup_scalar(typ)
+  if typ:isarray() then
+    return lookup_scalar(typ.type) .. "_" .. tostring(typ.N)
+  end
+  return ctypes[typ]
+end
+
+local function lookup_scalar_base(typ)
+  if typ:isarray() then
+    return lookup_scalar_base(typ.type)
+  end
+  return ctypes[typ]
+end
+
+local function lookup_field(typ)
+  if not typ then return end
+  if typ:isarray() then
+    local prefix, suffix = lookup_field(typ.type)
+    return prefix, suffix .. "[" .. typ.N .. "]"
+  end
+  return ctypes[typ], ""
+end
+
+local function get_type_in_rotation(types, i)
+  return types[((i - 1) % #types) + 1]
+end
+
+
+local function generate_array_wrapper(typ, N)
+  local name = lookup_scalar(typ) .. "_"
+  local parts = terralib.newlist({"typedef struct " .. name .. N .. " {"})
+  local prefix, suffix = lookup_field(typ[N])
+  parts:insert(prefix .. " x" .. suffix .. ";")
+  parts:insert("} " .. name .. N .. ";")
+  return parts:concat(" ")
+end
+
 local function generate_uniform_struct(name, typ, N)
   local parts = terralib.newlist({"typedef struct " .. name .. N .. " {"})
+  local prefix, suffix = lookup_field(typ)
   for i = 1, N do
-    parts:insert(ctypes[typ] .. " f" .. i .. ";")
+    parts:insert(prefix .. " f" .. i .. suffix .. ";")
   end
   parts:insert("} " .. name .. N .. ";")
   return parts:concat(" ")
@@ -56,8 +95,9 @@ end
 local function generate_nonuniform_struct(name, types, N)
   local parts = terralib.newlist({"typedef struct " .. name .. N .. " {"})
   for i = 1, N do
-    local typ = types[((i - 1) % #types) + 1]
-    parts:insert(ctypes[typ] .. " f" .. i .. ";")
+    local typ = get_type_in_rotation(types, i)
+    local prefix, suffix = lookup_field(typ)
+    parts:insert(prefix .. " f" .. i .. suffix .. ";")
   end
   parts:insert("} " .. name .. N .. ";")
   return parts:concat(" ")
@@ -67,63 +107,120 @@ local function generate_void_function(name)
   return "void " .. name .. "() {}"
 end
 
+local function generate_scalar_exprs(argname, typ, exprlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      exprlist:insert(argname .. ".x[" .. j .. "]")
+    end
+  else
+    exprlist:insert(argname)
+  end
+end
+
 local function generate_uniform_scalar_function(name, typ, N)
   local arglist = terralib.newlist()
   for i = 1, N do
-    arglist:insert(ctypes[typ] .. " x" .. i)
+    arglist:insert(lookup_scalar(typ) .. " x" .. i)
   end
   local exprlist = terralib.newlist()
   for i = 1, N do
-    exprlist:insert("x" .. i)
+    generate_scalar_exprs("x" .. i, typ, exprlist)
   end
-  return ctypes[typ] .. " " .. name .. N .. "(" .. arglist:concat(", ") .. ") { return " .. exprlist:concat(" + ") .. "; }"
+  return lookup_scalar_base(typ) .. " " .. name .. N .. "(" .. arglist:concat(", ") .. ") { return " .. exprlist:concat(" + ") .. "; }"
 end
 
 local function generate_nonuniform_scalar_function(name, types, N)
   local arglist = terralib.newlist()
   for i = 1, N do
-    local typ = types[((i - 1) % #types) + 1]
-    arglist:insert(ctypes[typ] .. " x" .. i)
+    local typ = get_type_in_rotation(types, i)
+    arglist:insert(lookup_scalar(typ) .. " x" .. i)
   end
   local exprlist = terralib.newlist()
   for i = 1, N do
-    exprlist:insert("x" .. i)
+    local typ = get_type_in_rotation(types, i)
+    generate_scalar_exprs("x" .. i, typ, exprlist)
   end
   return "double " .. name .. N .. "(" .. arglist:concat(", ") .. ") { return " .. exprlist:concat(" + ") .. "; }"
 end
 
-local function generate_aggregate_one_arg_function(name, aggname, N)
+local function generate_aggregate_one_field_stat(field, inc, typ, statlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      statlist:insert(field .. "[" .. j .. "] += " .. inc .. ";")
+    end
+  else
+    statlist:insert(field .. " += " .. inc .. ";")
+  end
+end
+
+local function generate_uniform_aggregate_one_arg_function(name, aggname, typ, N)
   local statlist = terralib.newlist()
   for i = 1, N do
-    statlist:insert("x.f" .. i .. " += " .. i .. ";")
+    generate_aggregate_one_field_stat("x.f" .. i, i, typ, statlist)
   end
   return aggname .. N .. " " .. name .. N .. "(" .. aggname .. N .. " x) { " .. statlist:concat(" ") .. " return x; }"
 end
 
-local function generate_aggregate_two_arg_function(name, aggname, N)
+local function generate_nonuniform_aggregate_one_arg_function(name, aggname, types, N)
   local statlist = terralib.newlist()
   for i = 1, N do
-    statlist:insert("x.f" .. i .. " += y.f" .. i .. ";")
+    local typ = get_type_in_rotation(types, i)
+    generate_aggregate_one_field_stat("x.f" .. i, i, typ, statlist)
+  end
+  return aggname .. N .. " " .. name .. N .. "(" .. aggname .. N .. " x) { " .. statlist:concat(" ") .. " return x; }"
+end
+
+local function generate_aggregate_two_field_stat(field1, field2, typ, statlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      statlist:insert(field1 .. "[" .. j .. "] += " .. field2 .. "[" .. j .. "];")
+    end
+  else
+    statlist:insert(field1 .. " += " .. field2 .. ";")
+  end
+end
+
+local function generate_uniform_aggregate_two_arg_function(name, aggname, typ, N)
+  local statlist = terralib.newlist()
+  for i = 1, N do
+    generate_aggregate_two_field_stat("x.f" .. i, "y.f" .. i, typ, statlist)
   end
   return aggname .. N .. " " .. name .. N .. "(" .. aggname .. N .. " x, " .. aggname .. N .. " y) { " .. statlist:concat(" ") .. " return x; }"
 end
 
-local uniform_names = terralib.newlist({"q", "r", "s", "t", "u", "v"})
-local types = {uint8, int16, int32, int64, float, double}
+local function generate_nonuniform_aggregate_two_arg_function(name, aggname, types, N)
+  local statlist = terralib.newlist()
+  for i = 1, N do
+    local typ = get_type_in_rotation(types, i)
+    generate_aggregate_two_field_stat("x.f" .. i, "y.f" .. i, typ, statlist)
+  end
+  return aggname .. N .. " " .. name .. N .. "(" .. aggname .. N .. " x, " .. aggname .. N .. " y) { " .. statlist:concat(" ") .. " return x; }"
+end
 
-local nonuniform_names = terralib.newlist({"w", "x"})
+local base_types = {uint8, int16, int32, int64, float, double}
+
+local uniform_names = terralib.newlist({"q", "r", "s", "t", "u", "v",
+                                        "qq", "rr", "ss", "tt", "uu", "vv"})
+local types = {uint8, int16, int32, int64, float, double,
+               uint8[2], int16[2], int32[2], int64[2], float[2], double[2]}
+
+local nonuniform_names = terralib.newlist({"w", "x", "y", "z", "zz"})
 local type_rotations = {
   {uint8, int16, int32, int64, double},
   {float, float, uint8, uint8, int16, int32, int64},
+  {uint8, int16[2], int64, float[3], double[2]},
+  {float, float[2]},
+  {double, double[4]},
 }
 
 local all_names = terralib.newlist()
 all_names:insertall(uniform_names)
 all_names:insertall(nonuniform_names)
 
-local uniform_scalar_names = terralib.newlist({"b", "c", "d", "e", "f", "g"})
+local uniform_scalar_names = terralib.newlist({"b", "c", "d", "e", "f", "g",
+                                               "bb", "cc", "dd", "ee", "ff", "gg"})
 
-local nonuniform_scalar_names = terralib.newlist({"h", "i"})
+local nonuniform_scalar_names = terralib.newlist({"h", "i", "j", "k", "kk"})
 
 local all_scalar_names = terralib.newlist()
 all_scalar_names:insertall(uniform_scalar_names)
@@ -135,6 +232,13 @@ do
 
   definitions:insert(generate_uniform_struct("p", nil, 0))
   definitions:insert("")
+
+  for i, typ in ipairs(base_types) do
+    for N = 1, MAX_ARRAY_N do
+      definitions:insert(generate_array_wrapper(typ, N))
+    end
+    definitions:insert("")
+  end
 
   for i, typ in ipairs(types) do
     local name = uniform_names[i]
@@ -172,21 +276,41 @@ do
     definitions:insert("")
   end
 
-  definitions:insert(generate_aggregate_one_arg_function("cp", "p", 0))
+  definitions:insert(generate_uniform_aggregate_one_arg_function("cp", "p", nil, 0))
   definitions:insert("")
 
-  for _, name in ipairs(all_names) do
+  for i, typ in ipairs(types) do
+    local name = uniform_names[i]
     for N = 1, MAX_N do
       definitions:insert(
-        generate_aggregate_one_arg_function("c" .. name, name, N))
+        generate_uniform_aggregate_one_arg_function("c" .. name, name, typ, N))
     end
     definitions:insert("")
   end
 
-  for _, name in ipairs(all_names) do
+  for i, type_rotation in ipairs(type_rotations) do
+    local name = nonuniform_names[i]
     for N = 1, MAX_N do
       definitions:insert(
-        generate_aggregate_two_arg_function("c2" .. name, name, N))
+        generate_nonuniform_aggregate_one_arg_function("c" .. name, name, type_rotation, N))
+    end
+    definitions:insert("")
+  end
+
+  for i, typ in ipairs(types) do
+    local name = uniform_names[i]
+    for N = 1, MAX_N do
+      definitions:insert(
+        generate_uniform_aggregate_two_arg_function("c2" .. name, name, typ, N))
+    end
+    definitions:insert("")
+  end
+
+  for i, type_rotation in ipairs(type_rotations) do
+    local name = nonuniform_names[i]
+    for N = 1, MAX_N do
+      definitions:insert(
+        generate_nonuniform_aggregate_two_arg_function("c2" .. name, name, type_rotation, N))
     end
     definitions:insert("")
   end
@@ -201,13 +325,35 @@ local function generate_void_terra(mod, name)
   mod[name] = f
 end
 
+local function lookup_scalar_terra(typ)
+  if typ:isarray() then
+    return c[lookup_scalar(typ)]
+  end
+  return typ
+end
+
+local function generate_scalar_exprs_terra(arg, typ, exprlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      exprlist:insert(`arg.x[j])
+    end
+  else
+    exprlist:insert(arg)
+  end
+end
+
 local function generate_uniform_scalar_terra(mod, name, typ, N)
+  local argtype = lookup_scalar_terra(typ)
   local args = terralib.newlist()
   for i = 1, N do
-    args:insert(terralib.newsymbol(typ, "x" .. i))
+    args:insert(terralib.newsymbol(argtype, "x" .. i))
+  end
+  local exprlist = terralib.newlist()
+  for _, arg in ipairs(args) do
+    generate_scalar_exprs_terra(arg, typ, exprlist)
   end
   local terra f([args])
-    return [args:reduce(function(x, y) return `x + y end)]
+    return [exprlist:reduce(function(x, y) return `x + y end)]
   end
   f:setname(name .. N)
   f:setinlined(false)
@@ -217,24 +363,43 @@ end
 local function generate_nonuniform_scalar_terra(mod, name, types, N)
   local args = terralib.newlist()
   for i = 1, N do
-    local typ = types[((i - 1) % #types) + 1]
-    args:insert(terralib.newsymbol(typ, "x" .. i))
+    local typ = get_type_in_rotation(types, i)
+    local argtype = lookup_scalar_terra(typ)
+    args:insert(terralib.newsymbol(argtype, "x" .. i))
+  end
+  local exprlist = terralib.newlist()
+  for i, arg in ipairs(args) do
+    local typ = get_type_in_rotation(types, i)
+    generate_scalar_exprs_terra(arg, typ, exprlist)
   end
   local terra f([args])
-    return [args:reduce(function(x, y) return `x + y end)]
+    return [exprlist:reduce(function(x, y) return `x + y end)]
   end
   f:setname(name .. N)
   f:setinlined(false)
   mod[name .. N] = f
 end
 
+local function generate_aggregate_one_field_stats_terra(field, typ, inc, statlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      statlist:insert(quote [field][j] = [field][j] + inc end)
+    end
+  else
+    statlist:insert(quote [field] = [field] + inc end)
+  end
+end
+
 local function generate_aggregate_one_arg_terra(mod, name, aggtyp, N)
   local terra f(x : aggtyp)
     escape
+      local statlist = terralib.newlist()
       for i = 1, N do
-        local field = "f" .. i
-        emit quote x.[field] = x.[field] + i end
+        local field = `x.["f" .. i]
+        local ftype = field:gettype()
+        generate_aggregate_one_field_stats_terra(field, ftype, i, statlist)
       end
+      emit quote [statlist] end
     end
     return x
   end
@@ -243,13 +408,28 @@ local function generate_aggregate_one_arg_terra(mod, name, aggtyp, N)
   mod[name .. N] = f
 end
 
+local function generate_aggregate_two_field_stats_terra(field1, field2, typ, statlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      statlist:insert(quote [field1][j] = [field1][j] + [field2][j] end)
+    end
+  else
+    statlist:insert(quote [field1] = [field1] + [field2] end)
+  end
+end
+
 local function generate_aggregate_two_arg_terra(mod, name, aggtyp, N)
   local terra f(x : aggtyp, y : aggtyp)
     escape
+      local statlist = terralib.newlist()
       for i = 1, N do
-        local field = "f" .. i
-        emit quote x.[field] = x.[field] + y.[field] end
+        local fname = "f" .. i
+        local field1 = `x.["f" .. i]
+        local field2 = `y.["f" .. i]
+        local ftype = field1:gettype()
+        generate_aggregate_two_field_stats_terra(field1, field2, ftype, statlist)
       end
+      emit quote [statlist] end
     end
     return x
   end
@@ -292,40 +472,57 @@ end
 
 -- Generate a unique exit condition for each test site.
 local exit_condition = 1
-local teq = macro(
-  function(arg, value)
-    exit_condition = exit_condition + 1
-    return quote
-      if arg ~= value then
-        return exit_condition -- failure
-      end
+local function generate_teq(arg, value)
+  exit_condition = exit_condition + 1
+  return quote
+    if arg ~= value then
+      return exit_condition -- failure
     end
-  end)
+  end
+end
+local teq = macro(generate_teq)
+
+local function generate_field_init(field, typ, init, statlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      statlist:insert(quote field[j] = init end)
+    end
+  else
+    statlist:insert(quote field = init end)
+  end
+end
 
 local init_fields = macro(
   function(arg, value, num_fields)
-    return quote
-      escape
-        for i = 1, num_fields:asvalue() do
-          emit quote
-            arg.["f"..i] = value*i
-          end
-        end
-      end
+    local statlist = terralib.newlist()
+    for i = 1, num_fields:asvalue() do
+      local field = `arg.["f" .. i]
+      local ftype = field:gettype()
+      generate_field_init(field, ftype, `value*i, statlist)
     end
+
+    return quote [statlist] end
   end)
+
+local function generate_field_check(field, typ, expected, statlist)
+  if typ:isarray() then
+    for j = 0, typ.N-1 do
+      statlist:insert(generate_teq(`field[j], expected))
+    end
+  else
+    statlist:insert(generate_teq(field, expected))
+  end
+end
 
 local check_fields = macro(
   function(arg, value, num_fields)
-    return quote
-      escape
-        for i = 1, num_fields:asvalue() do
-          emit quote
-            teq(arg.["f"..i], value*i)
-          end
-        end
-      end
+    local statlist = terralib.newlist()
+    for i = 1, num_fields:asvalue() do
+      local field = `arg.["f" .. i]
+      local ftype = field:gettype()
+      generate_field_check(field, ftype, `value*i, statlist)
     end
+    return quote [statlist] end
   end)
 
 -- Check functions with zero arguments/fields.
@@ -339,18 +536,37 @@ terra check_zero()
 end
 check_zero()
 
+local function generate_scalar_args(typ, i, arglist)
+  if typ:isarray() then
+    local expected_result = 0
+    local values = terralib.newlist()
+    for j = 0, typ.N-1 do
+      values:insert(i)
+      expected_result = expected_result + i
+    end
+    local arrtyp = lookup_scalar_terra(typ)
+    arglist:insert(`arrtyp { x = arrayof(typ.type, values) })
+    return expected_result
+  end
+
+  arglist:insert(i)
+  return i
+end
+
 -- Check functions of scalar arguments.
-for _, name in ipairs(all_scalar_names) do
+for i, typ in ipairs(types) do
+  local name = uniform_scalar_names[i]
   for N = 1, MAX_N do
+    local cfunc = c["c" .. name .. N]
+    local tfunc = t["t" .. name .. N]
+    local test_name = "N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype())
+    print("running scalar test for " .. test_name)
     local arglist = terralib.newlist()
     local expected_result = 0
     for i = 1, N do
-      arglist:insert(i)
-      expected_result = expected_result + i
+      expected_result = expected_result + generate_scalar_args(typ, i, arglist)
     end
     assert(expected_result < 255, "value is too large to fit in uint8, not safe to test")
-    local cfunc = c["c" .. name .. N]
-    local tfunc = t["t" .. name .. N]
     local terra check()
       teq(cfunc(arglist), expected_result)
       teq(tfunc(arglist), expected_result)
@@ -359,7 +575,33 @@ for _, name in ipairs(all_scalar_names) do
     local ok = check()
     if ok ~= 0 then
       print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
-      error("scalar test failed for N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. ": error code " .. tostring(ok))
+      error("scalar test failed for " .. test_name .. ": error code " .. tostring(ok))
+    end
+  end
+end
+for i, type_rotation in ipairs(type_rotations) do
+  local name = nonuniform_scalar_names[i]
+  for N = 1, MAX_N do
+    local cfunc = c["c" .. name .. N]
+    local tfunc = t["t" .. name .. N]
+    local test_name = "N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype())
+    print("running scalar test for " .. test_name)
+    local arglist = terralib.newlist()
+    local expected_result = 0
+    for i = 1, N do
+      local typ = get_type_in_rotation(type_rotation, i)
+      expected_result = expected_result + generate_scalar_args(typ, i, arglist)
+    end
+    assert(expected_result < 255, "value is too large to fit in uint8, not safe to test")
+    local terra check()
+      teq(cfunc(arglist), expected_result)
+      teq(tfunc(arglist), expected_result)
+      return 0
+    end
+    local ok = check()
+    if ok ~= 0 then
+      print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
+      error("scalar test failed for " .. test_name .. ": error code " .. tostring(ok))
     end
   end
 end
@@ -367,12 +609,14 @@ end
 -- Check functions of one aggregate argument.
 for _, name in ipairs(all_names) do
   for N = 1, MAX_N do
-    local aggtyp = c[name .. N]
+    local aggtype = c[name .. N]
     local cfunc = c["c" .. name .. N]
     local tfunc = t["t" .. name .. N]
+    local test_name = "N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. " where " .. tostring(aggtype) .. "=" .. tostring(aggtype:getentries():map(function(f) return tostring(f.field) .. "=" .. tostring(f.type) end))
+    print("running aggregate test for " .. test_name)
     assert(11 * N < 255, "value is too large to fit in uint8, not safe to test")
     local terra check()
-      var x : aggtyp
+      var x : aggtype
       init_fields(x, 10, N)
       var cx = cfunc(x)
       check_fields(x, 10, N)
@@ -385,7 +629,7 @@ for _, name in ipairs(all_names) do
     local ok = check()
     if ok ~= 0 then
       print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
-      error("aggregate test failed for N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. " where " .. tostring(aggtyp) .. "=" .. tostring(aggtyp:getentries():map(function(f) return tostring(f.field) .. "=" .. tostring(f.type) end)) .. ": error code " .. tostring(ok))
+      error("aggregate test failed for " .. test_name .. ": error code " .. tostring(ok))
     end
   end
 end
@@ -393,14 +637,16 @@ end
 -- Check functions of two aggregate arguments.
 for _, name in ipairs(all_names) do
   for N = 1, MAX_N do
-    local aggtyp = c[name .. N]
+    local aggtype = c[name .. N]
     local cfunc = c["c2" .. name .. N]
     local tfunc = t["t2" .. name .. N]
+    local test_name = "N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. " where " .. tostring(aggtype) .. "=" .. tostring(aggtype:getentries():map(function(f) return tostring(f.field) .. "=" .. tostring(f.type) end))
+    print("running aggregate test for " .. test_name)
     assert(11 * N < 255, "value is too large to fit in uint8, not safe to test")
     local terra check()
-      var x : aggtyp
+      var x : aggtype
       init_fields(x, 10, N)
-      var y : aggtyp
+      var y : aggtype
       init_fields(y, 1, N)
       var cx = cfunc(x, y)
       check_fields(x, 10, N)
@@ -413,7 +659,7 @@ for _, name in ipairs(all_names) do
     local ok = check()
     if ok ~= 0 then
       print(terralib.saveobj(nil, "llvmir", {check=check}, nil, nil, false))
-      error("aggregate test failed for N=" .. tostring(N) .. ", " .. tostring(tfunc:gettype()) .. " where " .. tostring(aggtyp) .. "=" .. tostring(aggtyp:getentries():map(function(f) return tostring(f.field) .. "=" .. tostring(f.type) end)) .. ": error code " .. tostring(ok))
+      error("aggregate test failed for " .. test_name .. ": error code " .. tostring(ok))
     end
   end
 end

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -7,18 +7,18 @@
 --
 --  * Pass/return an empty struct.
 --
---  * For each type in {int8, int16, int32, int64, float, double}:
---      * Pass 1..N scalar arguments of this type, and return the same type.
+--  * For T in {uint8, int16, int32, int64, float, double,
+--              uint8[2], int16[2], int32[2], int64[2], float[2], double[2]}:
+--     1. Pass 1..N arguments of type T, and return T.
+--     2. Pass (and return) a single struct argument with 1..N fields of type T.
+--     3. Pass two struct arguments, as above, and return same struct.
 --
---  * For each type in {int8, int16, int32, int64, float, double}:
---      * Pass (and return) a single struct argument with 1..N fields
---        of the type above.
+--  * As above, but with arguments/fields picked from a rotating set of types.
 --
---  * For each type in {int8, int16, int32, int64, float, double}:
---      * Pass two struct arguments, as above, and return same struct.
---
---  * As each of the three cases above, but with arguments/fields
---    picked from a rotating set of types.
+--  * Note: arrays (uint8[2], etc.) passed as individual arguments (not struct
+--    fields) are wrapped in a single-field struct because otherwise C arrays
+--    are passed by reference. While Terra is capable of passing such types by
+--    value, C is not, so there is no way to do a comparison.
 --
 -- A couple notable features (especially compared to cconv.t):
 --
@@ -33,8 +33,8 @@
 --    Terra's output. A command to generate the LLVM IR is shown (commented)
 --    at the bottom of the file.
 
+local MAX_N = 9 -- Needs to be <= 23 to avoid overflowing uint8.
 local MAX_ARRAY_N = 4
-local MAX_N = 9 -- Needs to be <= 22 to avoid overflowing uint8.
 
 local ctypes = {
   [uint8] = "uint8_t",

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -156,7 +156,7 @@ do
   definitions:insert(generate_aggregate_one_arg_function("cp", "p", 0))
   definitions:insert("")
 
-  for i, name in ipairs(uniform_names) do
+  for _, name in ipairs(uniform_names) do
     for N = 1, 9 do
       definitions:insert(
         generate_aggregate_one_arg_function("c" .. name, name, N))
@@ -164,7 +164,7 @@ do
     definitions:insert("")
   end
 
-  for i, name in ipairs(nonuniform_names) do
+  for _, name in ipairs(nonuniform_names) do
     for N = 1, 9 do
       definitions:insert(
         generate_aggregate_one_arg_function("c" .. name, name, N))
@@ -244,13 +244,13 @@ end
 
 generate_aggregate_one_arg_terra(t, "tp", c["p0"], 0)
 
-for i, name in ipairs(uniform_names) do
+for _, name in ipairs(uniform_names) do
   for N = 1, 9 do
     generate_aggregate_one_arg_terra(t, "t" .. name, c[name .. N], N)
   end
 end
 
-for i, name in ipairs(nonuniform_names) do
+for _, name in ipairs(nonuniform_names) do
   for N = 1, 9 do
     generate_aggregate_one_arg_terra(t, "t" .. name, c[name .. N], N)
   end
@@ -322,6 +322,7 @@ local check_fields = macro(
     end
   end)
 
+-- Part 1: check all of the scalar argument functions.
 terra part1()
   c.ca0()
   t.ta0()
@@ -483,133 +484,54 @@ end
 part1:compile() -- workaround: function at line 620 has more than 60 upvalues
 -- part1:printpretty(false)
 
+-- Part 2: check the one-arg aggregate functions.
 terra part2()
   var x0 : c.p0
   var cx0 = c.cp0(x0)
   var tx0 = t.tp0(x0)
 
   escape
-    for i, qi in ipairs(qs) do
-      local cqi = cqs[i]
-      local tqi = tqs[i]
-      emit quote
-        var xi : qi
-        init_fields(xi, 10, i)
-        var cxi = cqi(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = tqi(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
+    for _, name in ipairs(uniform_names) do
+      for N = 1, 9 do
+        local aggtyp = c[name .. N]
+        local cfunc = c["c" .. name .. N]
+        local tfunc = t["t" .. name .. N]
+        emit quote
+          var x : aggtyp
+          init_fields(x, 10, N)
+          var cx = cfunc(x)
+          check_fields(x, 10, N)
+          check_fields(cx, 11, N)
+          var tx = tfunc(x)
+          check_fields(x, 10, N)
+          check_fields(tx, 11, N)
+        end
       end
     end
   end
 
   escape
-    for i, ri in ipairs(rs) do
-      local cri = crs[i]
-      local tri = trs[i]
-      emit quote
-        var xi : ri
-        init_fields(xi, 10, i)
-        var cxi = cri(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = tri(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
-      end
-    end
-  end
-
-  escape
-    for i, si in ipairs(ss) do
-      local csi = css[i]
-      local tsi = tss[i]
-      emit quote
-        var xi : si
-        init_fields(xi, 10, i)
-        var cxi = csi(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = tsi(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
-      end
-    end
-  end
-
-  escape
-    for i, ti in ipairs(ts) do
-      local cti = cts[i]
-      local tti = tts[i]
-      emit quote
-        var xi : ti
-        init_fields(xi, 10, i)
-        var cxi = cti(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = tti(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
-      end
-    end
-  end
-
-  escape
-    for i, ui in ipairs(us) do
-      local cui = cus[i]
-      local tui = tus[i]
-      emit quote
-        var xi : ui
-        init_fields(xi, 10, i)
-        var cxi = cui(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = tui(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
-      end
-    end
-  end
-
-  escape
-    for i, vi in ipairs(vs) do
-      local cvi = cvs[i]
-      local tvi = tvs[i]
-      emit quote
-        var xi : vi
-        init_fields(xi, 10, i)
-        var cxi = cvi(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = tvi(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
-      end
-    end
-  end
-
-  escape
-    for i, wi in ipairs(ws) do
-      local cwi = cws[i]
-      local twi = tws[i]
-      emit quote
-        var xi : wi
-        init_fields(xi, 10, i)
-        var cxi = cwi(xi)
-        check_fields(xi, 10, i)
-        check_fields(cxi, 11, i)
-        var txi = twi(xi)
-        check_fields(xi, 10, i)
-        check_fields(txi, 11, i)
+    for _, name in ipairs(nonuniform_names) do
+      for N = 1, 9 do
+        local aggtyp = c[name .. N]
+        local cfunc = c["c" .. name .. N]
+        local tfunc = t["t" .. name .. N]
+        emit quote
+          var x : aggtyp
+          init_fields(x, 10, N)
+          var cx = cfunc(x)
+          check_fields(x, 10, N)
+          check_fields(cx, 11, N)
+          var tx = tfunc(x)
+          check_fields(x, 10, N)
+          check_fields(tx, 11, N)
+        end
       end
     end
   end
 
   return 0
 end
--- part2:printpretty(false)
 
 terra main()
   var err = part1()


### PR DESCRIPTION
This PR includes substantial fixes to the PPC64le calling convention for passing structs. In particular, PPC64le now passes the `cconv.t` test, as well as `cconv_more.t` (which is substantially upgraded in this PR).

The test `cconv_more.t` has been upgraded to use metaprogramming, so that it's easier to extend and modify parameters. In particular the test covers:

 * Functions with `N` scalar arguments (where `N` can be as high as 22, though it defaults to 12 for speed in the CI) for types `int8`, `int16`, `int32`, `int64`, `float`, `double` as well as `T[2]` for all the above types.
 * Same, but with a struct of `N` fields as a single argument.
 * Same, but with two arguments of this struct type instead of one.
 * Same as the above three cases, but with various rotations through sets of types designed to test various edge cases.

The test is also set to helpfully print out the failing LLVM bitcode (if any), which makes debugging immensely easier.

TODO:

 - [x] Refactor, particularly to decide where the PPC64le code should go.
 - [ ] Add `cconv_more.t` tests for nested structs (if possible, may not be easy given current framework). Right now we have this through `cconv.t` but it would be good to be more comprehensive.
 - [x] Add `cconv_more.t` tests for arrays (if possible, may not be easy given current framework). Right now we have this through `cconv.t` but it would be good to be more comprehensive.