### PR TITLE
Fix for type cache initialization on PPC64le

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -4897,4 +4897,8 @@ function terra.initdebugfns(traceback,backtrace,lookupsymbol,lookupline,disas)
     terra.disas = terra.cast(FP({po,terra.types.uint64,terra.types.uint64},{}),disas)
 end
 
+-- initialize type table for a few basic types
+terra.cast(uint64, 1ULL)
+terra.cast(int64, 1LL)
+
 _G["terralib"] = terra --terra code can't use "terra" because it is a keyword


### PR DESCRIPTION
Terra seems to rely on [this code path](https://github.com/terralang/terra/blob/5bb16734ff1ce6afe00cd56be2670dae04531f6a/src/terralib.lua#L4883-L4898) being executed to initialize some type cache machinery. This currently happens only on platforms where debug info is enabled (i.e., x86 only). Therefore on PPC64le, this initialization does not happen, leading to errors down the line.

For now, make sure that initialization is in place so that we don't depend on the user doing `terralib.cast(uint64, 1ULL)` or similar to make their programs work.