### PR TITLE
Disable coverage3.t on PPC64le

### DIFF
--- a/tests/coverage3.t
+++ b/tests/coverage3.t
@@ -1,7 +1,8 @@
--- FIXME: Test currently fails on Windows
+-- FIXME: Test currently fails on Windows (and PPC64le too)
 -- https://github.com/terralang/terra/issues/287
 local ffi = require("ffi")
-if ffi.os == "Windows" then
+if ffi.os == "Windows" or ffi.arch == "ppc64le" then
+    print("this test is not compatible with " .. ffi.os .. " " .. ffi.arch)
     os.exit()
 end
 


### PR DESCRIPTION
This test has been known to [fail on Windows](https://github.com/terralang/terra/issues/287), but I hadn't had time to debug it properly. It also fails on PPC64le.

The error message seems to originate from LuaJIT (in this case, Moonjit): https://github.com/moonjit/moonjit/blob/eb7168839138591e0d2a1751122966603a8b87c8/src/lj_errmsg.h#L179

Therefore it seems this is simply unimplemented behavior in LuaJIT/Moonjit, and therefore there is not much we can do about it from our end.

This PR shuts off the test on PPC64le.
