### PR TITLE
Run LLVM shutdown via atexit when possible

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -103,6 +103,7 @@ int main(int argc, char **argv) {
     if (terra_initwithoptions(L, &options)) doerror(L);
 
     setupcrashsignal(L);
+    int registered = atexit(terra_llvmshutdown);
 
     if (options.cmd_line_chunk != NULL) {
         if (terra_dostring(L, options.cmd_line_chunk)) doerror(L);
@@ -125,7 +126,7 @@ int main(int argc, char **argv) {
     }
 
     lua_close(L);
-    terra_llvmshutdown();
+    if (registered != 0) terra_llvmshutdown();
 
     return 0;
 }


### PR DESCRIPTION
For context, see this thread: https://github.com/StanfordLegion/legion/issues/1297#issuecomment-1188635075

It seems that it is unsafe to call `atexit` inside a shared library loaded with `terralib.linklibrary`. For various reasons, turning this off in all possible libraries may not be feasible or reasonable. Instead, this PR attempts to make this safe by calling `terra_llvmshutdown` from `atexit` (falling back to just calling it at the end of `main` otherwise). While `atexit` can lead to some screwy behavior, this seems like the least-bad solution, in that it makes it possible to (I think safely) use `atexit` in libraries loaded by `terralib.linklibrary`, making this one less thing users need to think about (hopefully).

Why is this safe?

We call `atexit(terra_llvmshutdown)` before executing or initializing any Terra code. `atexit` handlers run in [LIFO order](https://cplusplus.com/reference/cstdlib/atexit/). Therefore, any `atexit` handlers registered by libraries loaded via `terralib.linklibrary` will have an opportunity to run before `terra_llvmshutdown` attempts to unload them.

The main thing I'm dissatisfied about in this change is that this also influences the explicit `exit(1)` code path. In the past, we did not attempt to register anything to run in these cases, and arguably, it's not even worth attempting to shut down LLVM on a non-clean exit. However, I'm not aware of a way to say "register this `atexit` handler only for the normal exit case", so I'm not sure what else to do about this.