### PR TITLE
Fix executables built on arm64 macOS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -173,11 +173,6 @@ SUPPORT_LIBRARY_FLAGS += $(LIBFFI_LIBS) $(LIBXML20_LIBS) $(LIBEDIT_LIBS)
 
 PACKAGE_DEPS += $(LUAJIT_LIB)
 
-#makes luajit happy on osx 10.6 (otherwise luaL_newstate returns NULL)
-ifeq ($(UNAME), Darwin)
-LFLAGS += -pagezero_size 10000 -image_base 100000000 
-endif
-
 CLANG_RESOURCE_DIRECTORY=$(CLANG_PREFIX)/lib/clang/$(LLVM_VERSION_NUM)
 
 ifeq ($(ENABLE_CUDA),1)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,13 +327,6 @@ target_compile_definitions(TerraExecutable
 )
 
 if(APPLE)
-  set_target_properties(TerraExecutable
-    PROPERTIES
-      # Makes LuaJIT happy (otherwise luaL_newstate returns NULL). Has to be
-      # set as a property otherwise target_link_libraries thinks the arguments
-      # are libraries.
-      LINK_FLAGS "-pagezero_size 10000 -image_base 100000000"
-  )
   target_link_libraries(TerraExecutable
     PRIVATE
       -Wl,-force_load,$<TARGET_LINKER_FILE:TerraLibrary>


### PR DESCRIPTION
This commit removes the addition of the `-pagezero_size` and `-image_base` linker flags.