### PR TITLE
More cleanup for unnecessary macOS linker flags

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -2,4 +2,4 @@
 
 source "https://rubygems.org"
 
-gem "github-pages", "~> 226"
+gem "github-pages", "~> 227"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.0.5)
+    activesupport (6.0.5.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -32,7 +32,7 @@ GEM
     ffi (1.15.5)
     forwardable-extended (2.6.0)
     gemoji (3.0.1)
-    github-pages (226)
+    github-pages (227)
       github-pages-health-check (= 1.17.9)
       jekyll (= 3.9.2)
       jekyll-avatar (= 0.7.0)
@@ -74,7 +74,7 @@ GEM
       liquid (= 4.0.3)
       mercenary (~> 0.3)
       minima (= 2.5.1)
-      nokogiri (>= 1.13.4, < 2.0)
+      nokogiri (>= 1.13.6, < 2.0)
       rouge (= 3.26.0)
       terminal-table (~> 1.4)
     github-pages-health-check (1.17.9)
@@ -212,7 +212,7 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.16.2)
-    nokogiri (1.13.6)
+    nokogiri (1.13.8)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     octokit (4.25.1)
@@ -245,7 +245,7 @@ GEM
     thread_safe (0.3.6)
     typhoeus (1.4.0)
       ethon (>= 0.9.0)
-    tzinfo (1.2.9)
+    tzinfo (1.2.10)
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
@@ -257,7 +257,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  github-pages (~> 226)
+  github-pages (~> 227)
 
 BUNDLED WITH
    2.1.4

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1238,14 +1238,11 @@ This program can then be compiled by linking against the Terra library
 
     # Linux
     c++ simple.cpp -o simple -I<path-to-terra-folder>/terra/include \
-    -L<path-to-terra-folder>/lib -lterra -ldl -pthread
+    -L<path-to-terra-folder>/lib -lterra_s -ldl -pthread
 
     # OSX
     c++ simple.cpp -o simple -I<path-to-terra-folder>/terra/include \
-    -L<path-to-terra-folder>/lib -lterra \
-    -pagezero_size 10000 -image_base 100000000
-
-Note the extra `pagezero_size` and `image_base` arguments on OSX. These are necessary for LuaJIT to run on OSX.
+    -L<path-to-terra-folder>/lib -lterra_s
 
 In addition to these modes, Terra code can be compiled to `.o` files which can be linked into an executable, or even compiled to an executable directly.
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -86,10 +86,7 @@ This program can then be compiled by linking against the Terra library
 
     # OSX
     c++ simple.cpp -o simple -I<path-to-terra-folder>/terra/include \
-    -L<path-to-terra-folder>/lib -lterra_s \
-    -pagezero_size 10000 -image_base 100000000
-
-Note the extra `pagezero_size` and `image_base` arguments on OSX. These are necessary for LuaJIT to run on OSX.
+    -L<path-to-terra-folder>/lib -lterra_s
 
 In addition to these modes, Terra code can be compiled to `.o` files which can be linked into an executable, or even compiled to an executable directly.
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -27,6 +27,10 @@ Installing Terra
 
 Terra currently runs Linux, macOS, FreeBSD, and 64-bit Windows. Binary releases for popular versions of these systems are available [online](https://github.com/terralang/terra/releases), and we recommend you use them if possible because building Terra requires a working install of LLVM and Clang, which can be difficult to get working.
 
+Note that as of macOS 10.15 Catalina, in order to include C headers in Terra you will need to define the following evironment variable:
+
+    export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+
 
 Running Terra
 =============
@@ -201,6 +205,13 @@ make install -j4 # tune this for how many cores you have
 ```
 
 This will install Terra into the `terra/install` directory.
+
+Please note that on macOS, the following is required to enable the
+C/C++ compiler (and Terra) to find the system headers:
+
+```
+export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+```
 
 CMake will attempt to auto-detect the location of LLVM on the
 system. If it is unable to do so (e.g., because LLVM is installed in a

--- a/tests/dynlib.t
+++ b/tests/dynlib.t
@@ -49,9 +49,6 @@ if ffi.os ~= "Windows" then
       flags:insert(lua_lib)
     end
     print(flags:concat(" "))
-    if ffi.os == "OSX" then
-        flags:insertall {"-pagezero_size","10000", "-image_base", "100000000"}
-    end
 
     terralib.saveobj("dynlib",{main = main},flags)
 


### PR DESCRIPTION
One test and some docs still had references to the (now unnecessary) `-pagezero_size 10000 -image_base 100000000` flags.