### PR TITLE
Upgrade CI to macOS 11

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -212,7 +212,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-16.04', 'ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04']
-        llvm: ['3.8', '6.0', '12', '14.0.0']
+        llvm: ['3.8', '6.0', '12', '14.0.6']
         exclude:
           - distro: 'ubuntu-18.04'
             llvm: '3.8'
@@ -229,11 +229,11 @@ jobs:
           - distro: 'ubuntu-20.04'
             llvm: '12'
           - distro: 'ubuntu-16.04'
-            llvm: '14.0.0'
+            llvm: '14.0.6'
           - distro: 'ubuntu-18.04'
-            llvm: '14.0.0'
+            llvm: '14.0.6'
           - distro: 'ubuntu-20.04'
-            llvm: '14.0.0'
+            llvm: '14.0.6'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh
@@ -266,7 +266,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04" "" 13.0.0 prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04" "" 13.0.1 prebuilt 2
       - uses: actions/upload-artifact@v2
         with:
           name: docker-ubuntu-18.04-x86_64-llvm-13

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'macos-10.15', 'windows-2022']
+        os: ['ubuntu-18.04', 'macos-11', 'windows-2022']
         llvm: ['5.0', '6.0', '7', '8', '9', '10', '11', '12', '13', '14']
         cmake: ['0', '1']
         cuda: ['0', '1']
@@ -30,37 +30,37 @@ jobs:
             llvm: '14'
 
           # macOS: exclude LLVM 5.0, 8-14 make, cuda/no-static/no-slib
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '5.0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '8'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '9'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '10'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '11'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '12'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '13'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '14'
             cmake: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             cuda: '1'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             static: '0'
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             slib: '0'
           # LLVM 10 binaries are broken on recent macOS
-          - os: 'macos-10.15'
+          - os: 'macos-11'
             llvm: '10'
 
           # Windows: exclude LLVM 5.0-10,12-14, make

--- a/travis.sh
+++ b/travis.sh
@@ -97,26 +97,26 @@ fi
 
 if [[ $(uname) = Darwin ]]; then
   if [[ $LLVM_CONFIG = llvm-config-14 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-14.0.0-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-14.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-14
-    ln -s clang+llvm-14.0.0-x86_64-apple-darwin/bin/clang clang-14
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.0-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
+    tar xf clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
+    ln -s clang+llvm-14.0.6-x86_64-apple-darwin/bin/llvm-config llvm-config-14
+    ln -s clang+llvm-14.0.6-x86_64-apple-darwin/bin/clang clang-14
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.6-x86_64-apple-darwin
   elif [[ $LLVM_CONFIG = llvm-config-13 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-13.0.0/clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-13.0.0-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-13.0.0-x86_64-apple-darwin/bin/llvm-config llvm-config-13
-    ln -s clang+llvm-13.0.0-x86_64-apple-darwin/bin/clang clang-13
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-13.0.0-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-13.0.1/clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz
+    tar xf clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz
+    ln -s clang+llvm-13.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-13
+    ln -s clang+llvm-13.0.1-x86_64-apple-darwin/bin/clang clang-13
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-13.0.1-x86_64-apple-darwin
   elif [[ $LLVM_CONFIG = llvm-config-12 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-12.0.1/clang+llvm-12.0.1-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-12.0.1-x86_64-apple-darwin.tar.xz
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-12.0.1/clang+llvm-12.0.1-x86_64-apple-darwin-macos11.tar.xz
+    tar xf clang+llvm-12.0.1-x86_64-apple-darwin-macos11.tar.xz
     ln -s clang+llvm-12.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-12
     ln -s clang+llvm-12.0.1-x86_64-apple-darwin/bin/clang clang-12
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-12.0.1-x86_64-apple-darwin
   elif [[ $LLVM_CONFIG = llvm-config-11 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-11.1.0-x86_64-apple-darwin.tar.xz
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-apple-darwin-macos11.tar.xz
+    tar xf clang+llvm-11.1.0-x86_64-apple-darwin-macos11.tar.xz
     ln -s clang+llvm-11.1.0-x86_64-apple-darwin/bin/llvm-config llvm-config-11
     ln -s clang+llvm-11.1.0-x86_64-apple-darwin/bin/clang clang-11
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-x86_64-apple-darwin


### PR DESCRIPTION
GitHub Actions is removing support for 10.15.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/