### PR TITLE
Add CI for AArch64 via Cirrus

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,4 +1,4 @@
-task:
+freebsd_task:
   name: FreeBSD
   freebsd_instance:
     matrix:
@@ -20,3 +20,14 @@ task:
     export MAKE=gmake
     export CC=cc
     bash travis.sh
+
+arm_task:
+  name: Linux AArch64
+  arm_container:
+    image: ubuntu:18.04
+  env:
+    llvm: 13.0.0
+    arch: aarch64
+    threads: 2
+  script: |
+    ./docker/install_script_multiarch.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -26,7 +26,7 @@ arm_task:
   arm_container:
     image: ubuntu:18.04
   env:
-    llvm: 13.0.0
+    llvm: 11.1.0
     arch: aarch64
     threads: 2
   script: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,7 +247,12 @@ jobs:
       matrix:
         distro: ['ubuntu-18.04']
         arch: ['arm64', 'ppc64le']
-        llvm: ['11.1.0']
+        llvm: ['13.0.0', '11.1.0']
+        exclude:
+          - arch: 'arm64'
+            llvm: '13.0.0'
+          - arch: 'ppc64le'
+            llvm: '11.1.0'
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,7 +247,7 @@ jobs:
       matrix:
         distro: ['ubuntu-18.04']
         arch: ['arm64', 'ppc64le']
-        llvm: ['13.0.0']
+        llvm: ['11.1.0']
     steps:
       - uses: actions/checkout@v1
       - run: ./travis.sh

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,20 @@
+# Release 1.0.5 (2022-08-16)
+
+This release stabilizes support for ARM (AArch64). On a variety of
+hardware (Graviton, NVIDIA Jetson), Terra now passes 100% of the test
+suite.
+
+## Improvements
+
+  * Fixes for multiple issues on AArch64, allowing Terra to pass 100%
+    of the test suite.
+  * Updated LuaJIT to obtain fixes for AArch64.
+
+## Known Issues
+
+  * On AArch64, Terra requires LLVM 11 or older. Newer LLVM versions
+    result in segfaults on some tests.
+
 # Release 1.0.4 (2022-07-08)
 
 This release stabilizes support for PPC64le. On POWER9 hardware, Terra

--- a/docker/install_script_multiarch.sh
+++ b/docker/install_script_multiarch.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+# because Cirrus gives us ARM containers and not VMs, we have to
+# extract the body of Dockerfile.ubuntu-prebuilt-multiarch here
+
+set -e
+
+apt-get update -qq
+apt-get install -qq build-essential cmake git python3 wget
+wget -nv https://github.com/terralang/llvm-build/releases/download/llvm-$llvm/clang+llvm-$llvm-$arch-linux-gnu.tar.xz
+tar xf clang+llvm-$llvm-$arch-linux-gnu.tar.xz
+mv clang+llvm-$llvm-$arch-linux-gnu /llvm
+rm clang+llvm-$llvm-$arch-linux-gnu.tar.xz
+echo "disabled: /terra/docker/install_cuda.sh"
+cd build
+cmake -DCMAKE_PREFIX_PATH=/llvm/install -DCMAKE_INSTALL_PREFIX=/terra_install ..
+make install -j$threads
+ctest --output-on-failure -j$threads

--- a/tests/class.t
+++ b/tests/class.t
@@ -23,7 +23,7 @@ struct C(Class(B)) {
 terra C:combine(a : int) : int
     return self.c + self.a + self.b + a
 end
-terra C:times2() : double
+terra C:times2() : int
     return self.a * 4
 end
 

--- a/tests/class6.t
+++ b/tests/class6.t
@@ -22,7 +22,7 @@ struct C(Class(B)) {
 terra C:combine(a : int) : int
     return self.c + self.a + self.b + a
 end
-terra C:times2() : double
+terra C:times2() : int
     return self.a * 4
 end
 

--- a/tests/coverage3.t
+++ b/tests/coverage3.t
@@ -1,7 +1,7 @@
--- FIXME: Test currently fails on Windows (and PPC64le too)
+-- FIXME: Test currently fails on Windows (and PPC64le/AArch64 too)
 -- https://github.com/terralang/terra/issues/287
 local ffi = require("ffi")
-if ffi.os == "Windows" or ffi.arch == "ppc64le" then
+if ffi.os == "Windows" or ffi.arch == "ppc64le" or ffi.arch == "arm64" then
     print("this test is not compatible with " .. ffi.os .. " " .. ffi.arch)
     os.exit()
 end

--- a/tests/vecobj.t
+++ b/tests/vecobj.t
@@ -46,6 +46,7 @@ end)
 -- There are two limitations of Moonjit on PPC64le that require workarounds:
 --  1. the printfloat callback results in a segfault
 --  2. passing arrays to Terra from Lua results in garbage
+-- Note: the second of these applies to AArch64 (ARM) as well
 
 if ffi.arch ~= "ppc64le" then
     printfloat = terralib.cast({float}->{},print)
@@ -68,7 +69,7 @@ end
 foo:printpretty(true,false)
 foo:disas()
 
-if ffi.arch ~= "ppc64le" then
+if ffi.arch ~= "ppc64le" and ffi.arch ~= "arm64" then
     assert(20 == foo({{1,2,3,4}},{{5,6,7,8}}))
 else
     terra call_foo(v0 : float, v1 : float, v2 : float, v3 : float, w0 : float, w1 : float, w2 : float, w3 : float)


### PR DESCRIPTION
Does not pass yet, so I won't merge, but this PR can be used to track pass rate for ARM on actual hardware (whereas emulation seems to suffer from additional failures beyond what ARM hardware experiences).