### PR TITLE
Fix a typo in atomicrmw.t test

### DIFF
--- a/tests/atomicrmw.t
+++ b/tests/atomicrmw.t
@@ -112,8 +112,8 @@ end
 terra atomic_xchg_pointer(x : &&int, y : &int)
   return terralib.atomicrmw("xchg", x, y, {ordering = "acq_rel"})
 end
-atomic_add_and_return:printpretty(false)
-atomic_add_and_return:disas()
+atomic_xchg_pointer:printpretty(false)
+atomic_xchg_pointer:disas()
 
 terra xchg_pointer()
   var i : int = 1


### PR DESCRIPTION
Shouldn't have a functional impact, but makes the output less confusing.