### PR TITLE
LLVM does not allow xchg on pointers

### DIFF
--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -3057,8 +3057,8 @@ function typecheck(topexp,luaenv,simultaneousdefinitions)
                     return e:aserror()
                 end
                 if e.operator == "xchg" then
-                  if not (addr.type.type:isintegral() or addr.type.type:isfloat() or addr.type.type:ispointer()) then
-                    diag:reporterror(e,"for operator " .. e.operator .. " address must be a pointer to an integral, floating point, or pointer type, but found ", addr.type.type)
+                  if not (addr.type.type:isintegral() or addr.type.type:isfloat()) then
+                    diag:reporterror(e,"for operator " .. e.operator .. " address must be a pointer to an integral or floating point type, but found ", addr.type.type)
                     return e:aserror()
                   end
                 elseif e.operator == "fadd" or e.operator == "fsub" then


### PR DESCRIPTION
So we're going to disallow it. This seems to be a case where LLVM's documentation does not match LLVM's implementation.

This is a breaking change. That's ok because:

 * The feature is experimental.
 * Any code that used the feature will hit a compile error (i.e., there will be no silent breaking changes).
 * Practically speaking, the number of users who use this is probably nil.