### PR TITLE
Enable CI on PPC64le via Ascent

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,6 +10,6 @@ build:
     - tar xf clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
     - export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$PWD/clang+llvm-14.0.0-powerpc64le-linux-gnu
     - cd build
-    - cmake .. -DTERRA_USE_CUDA=1
+    - cmake .. -DTERRA_ENABLE_CUDA=1
     - make -j8
     - ctest -j8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+# This CI configuration is intended to be run on Ascent. See:
+# https://code.ornl.gov/ecpcitest/csc335/terra
+
 build:
   tags:
     - nobatch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,7 +2,7 @@ build:
   tags:
     - nobatch
   script:
-    - module load gcc cuda
+    - module load gcc cuda cmake
     - cd build
     - cmake .. -DTERRA_USE_CUDA=1
     - make -j8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,9 @@
 # This CI configuration is intended to be run on Ascent. See:
 # https://code.ornl.gov/ecpcitest/csc335/terra
 
+variables:
+  GIT_STRATEGY: clone # workaround for filesystem issues
+
 build:
   tags:
     - nobatch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,7 @@ build:
     - module load gcc cuda cmake
     - wget -nv https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
     - tar xf clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
-    - export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:clang+llvm-14.0.0-powerpc64le-linux-gnu
+    - export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$PWD/clang+llvm-14.0.0-powerpc64le-linux-gnu
     - cd build
     - cmake .. -DTERRA_USE_CUDA=1
     - make -j8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,9 @@ build:
     - nobatch
   script:
     - module load gcc cuda cmake
+    - wget https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
+    - tar xf clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
+    - export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:clang+llvm-14.0.0-powerpc64le-linux-gnu
     - cd build
     - cmake .. -DTERRA_USE_CUDA=1
     - make -j8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,9 @@
+build:
+  tags:
+    - nobatch
+  script:
+    - module load gcc cuda
+    - cd build
+    - cmake .. -DTERRA_USE_CUDA=1
+    - make -j8
+    - ctest -j8

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,7 +6,7 @@ build:
     - nobatch
   script:
     - module load gcc cuda cmake
-    - wget https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
+    - wget -nv https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
     - tar xf clang+llvm-14.0.0-powerpc64le-linux-gnu.tar.xz
     - export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:clang+llvm-14.0.0-powerpc64le-linux-gnu
     - cd build

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -33,8 +33,13 @@
 --    Terra's output. A command to generate the LLVM IR is shown (commented)
 --    at the bottom of the file.
 
-local MAX_N = 9 -- Needs to be <= 23 to avoid overflowing uint8.
+local MAX_N = 12 -- Needs to be <= 23 to avoid overflowing uint8.
 local MAX_ARRAY_N = 4
+
+local ffi = require("ffi")
+if ffi.arch == "x64" then
+  MAX_N = 9 -- https://github.com/terralang/terra/issues/576
+end
 
 local ctypes = {
   [uint8] = "uint8_t",


### PR DESCRIPTION
You can see the CI instance at https://code.ornl.gov/ecpcitest/csc335/terra/-/pipelines .

Because of the way things are set up, this will not, unfortunately, run on PRs or commits. But I can configure the CI to run regularly so that we can ensure PPC64le builds continue to work.

This is also, by the way, our first CI coverage with CUDA using actual GPUs.