### PR TITLE
WebAssembly (wasm32/64) Calling Convention Fix

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1009,9 +1009,7 @@ struct CCallingConv {
         return 2;
     }
 
-    bool WasmIsSingletonOrEmpty(Type *t) {
-        return WasmPrimitiveCount(t) <= 1;
-    }
+    bool WasmIsSingletonOrEmpty(Type *t) { return WasmPrimitiveCount(t) <= 1; }
 
     void MergeValuePPC64(Type *t, std::vector<Type *> &elements, int64_t &bits) {
         StructType *st = dyn_cast<StructType>(t);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -994,7 +994,7 @@ struct CCallingConv {
         StructType *st = dyn_cast<StructType>(t);
         if (st) {
             return st->getNumElements() == 1 
-                && IsSingletonStruct(st->getTypeAtIndex(0));
+                && IsSingletonStruct(st->getElementType(0));
         }
 
         ArrayType *at = dyn_cast<ArrayType>(t);
@@ -1099,7 +1099,7 @@ struct CCallingConv {
         }
 
         // WASM passes all aggregates except singleton structures by reference
-        if (wasm_cconv && !IsSingletonStruct(t)) {
+        if (wasm_cconv && !IsSingletonStruct(t->type)) {
             return Argument(C_AGGREGATE_MEM, t);
         }
 


### PR DESCRIPTION
Fixes, under wasm32- and wasm64- triples, how terra passes aggregates by
value, to match clang/emscripten.

WebAssembly only passes single-value structs directly in registers [1], all other
structs (and all arrays) are passed indirectly.

It would be nice to have tests for this but I'm not really sure how to go about
creating them without pulling in a webassembly VM or Emscripten as
dependencies. This does allow my terra->wasm code to link against 
clang/Emscripten compiled libraries, for what it's worth.

[1] https://github.com/WebAssembly/tool-conventions/blob/main/BasicCABI.md

