### PR TITLE
Fix missing migration leftover from prev. commit

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -275,7 +275,7 @@ int terra_inittarget(lua_State *L) {
     } else {
 #ifdef __arm__
         // force hard float since we currently onlly work on platforms that have it
-        options->FloatABIType = FloatABI::Hard;
+        options.FloatABIType = FloatABI::Hard;
 #endif
     }
 


### PR DESCRIPTION
`options` changed from a pointer (taken as an argument) to a local object, but the arm code still referenced it as a pointer. Most likely the code has been broken on arm ever since but no one checked.