### PR TITLE
Upgrade FreeBSD to fix CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,8 +9,9 @@ freebsd_task:
       LLVM_VERSION: 11
       LLVM_VERSION: 12
       LLVM_VERSION: 13
-      LLVM_VERSION: 14
+      # LLVM_VERSION: 14
       LLVM_VERSION: 15
+      LLVM_VERSION: 16
     matrix:
       # USE_CMAKE: 0
       USE_CMAKE: 1

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_task:
   name: FreeBSD
   freebsd_instance:
     matrix:
-      image_family: freebsd-13-1
+      image_family: freebsd-13-2
       # image_family: freebsd-12-3
   env:
     matrix:


### PR DESCRIPTION
The LLVM 14 package seems to be missing for some reason, so let's see if we can work around it.