### PR TITLE
Fixes for macOS 13 Objective-C header files

### DIFF
--- a/tests/bug.t
+++ b/tests/bug.t
@@ -8,7 +8,7 @@ else
 
 
 local OC = require("lib/objc")
-local OCR = terralib.includec("objc/runtime.h")
+local OCR = terralib.includec("objc/runtime.h", {"-fblocks"})
 
 terra main()
 	var nsobject = OC.NSObject

--- a/tests/lib/objc.t
+++ b/tests/lib/objc.t
@@ -3,11 +3,11 @@ if ffi.os == "Windows" then
 	return
 end
 
-local C = terralib.includecstring [[
+local C = terralib.includecstring([[
 	#include <objc/objc.h>
 	#include <objc/message.h>
 	#include <stdio.h>
-]]
+]], {"-fblocks"})
 local mangleSelector
 
 


### PR DESCRIPTION
Apparently, on macOS the Objective-C headers now require `-fblocks`. Testing here to make sure that'll fly in macOS 11.