### PR TITLE
Remove call TargetMachine::adjustPassManager which is gone in LLVM 16

### DIFF
--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -152,7 +152,9 @@ void moduleToPTX(terra_State *T, llvm::Module *M, int major, int minor, std::str
 #endif
 
     llvm::legacy::PassManager PM;
+#if LLVM_VERSION < 160
     TargetMachine->adjustPassManager(PMB);
+#endif
 
     PMB.populateModulePassManager(PM);
 


### PR DESCRIPTION
Fixes CUDA build in LLVM 16.