### PR TITLE
Modernize use of LLVM pointer types

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1381,8 +1381,7 @@ struct CCallingConv {
                                arguments);
             }
         } else {
-            arguments.push_back(
-                    B->CreateLoad(value->getType()->getPointerElementType(), value));
+            arguments.push_back(B->CreateLoad(param_type, value));
         }
     }
 
@@ -1467,8 +1466,7 @@ struct CCallingConv {
             } else {
                 assert(!"unhandled argument kind");
             }
-            return B->CreateLoad(aggregate->getType()->getPointerElementType(),
-                                 aggregate);
+            return B->CreateLoad(info.returntype.type->type, aggregate);
         }
     }
     void GatherArgumentsAggReg(Type *type, std::vector<Type *> &arguments) {
@@ -3147,7 +3145,7 @@ struct FunctionEmitter {
             Value *addr = CreateConstGEP2_32(B, result, ttype, 0, i);
             B->CreateStore(values[i], addr);
         }
-        return B->CreateLoad(result->getType()->getPointerElementType(), result);
+        return B->CreateLoad(ttype, result);
     }
     void emitStmtList(Obj *stmts) {
         int NS = stmts->size();
@@ -3318,7 +3316,7 @@ struct FunctionEmitter {
                 BasicBlock *cond = createAndInsertBB("forcond");
                 B->CreateBr(cond);
                 setInsertBlock(cond);
-                Value *v = B->CreateLoad(vp->getType()->getPointerElementType(), vp);
+                Value *v = B->CreateLoad(t->type, vp);
                 Value *c = B->CreateOr(B->CreateAnd(emitCompare(T_lt, t, v, limitv),
                                                     emitCompare(T_gt, t, stepv, zero)),
                                        B->CreateAnd(emitCompare(T_gt, t, v, limitv),

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2616,8 +2616,8 @@ struct FunctionEmitter {
                     }
 
                     Obj objType;
-                    type.obj("type", &objType);
-                    if (t->type->getPointerElementType()->isIntegerTy(8)) {
+                    Types::PointsToType(&type, &objType);
+                    if (getType(&objType)->type->isIntegerTy(8)) {
                         Obj stringvalue;
                         exp->obj("value", &stringvalue);
                         Value *str = lookupSymbol<Value>(CU->symbols, &stringvalue);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2584,16 +2584,15 @@ struct FunctionEmitter {
                     assert(aggType->type->isPointerTy());
                     Obj objType;
                     Types::PointsToType(&aggTypeO, &objType);
+                    TType *objTType = getType(&objType);
 
                     idxExp = emitIndex(typeOfValue(&idx), 64, idxExp);
                     // otherwise we have a pointer access which will use a GEP instruction
                     std::vector<Value *> idxs;
                     Ty->EnsurePointsToCompleteType(&aggTypeO);
-                    Value *result =
-                            B->CreateGEP(getType(&objType)->type, valueExp, idxExp);
+                    Value *result = B->CreateGEP(objTType->type, valueExp, idxExp);
                     if (!exp->boolean("lvalue"))
-                        result = B->CreateLoad(result->getType()->getPointerElementType(),
-                                               result);
+                        result = B->CreateLoad(objTType->type, result);
                     return result;
                 }
             } break;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2689,7 +2689,7 @@ struct FunctionEmitter {
                                       // structvariable and perform any casts necessary
                     B->CreateStore(in, oe);
                 }
-                return B->CreateLoad(output->getType()->getPointerElementType(), output);
+                return B->CreateLoad(toT->type, output);
             } break;
             case T_cast: {
                 Obj a;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2363,7 +2363,7 @@ struct FunctionEmitter {
         int allocindex = entry.number("allocation");
 
         Value *addr = CreateConstGEP2_32(B, structPtr,
-                                         structPtr->getType()->getPointerElementType(), 0,
+                                         getType(structType)->type, 0,
                                          allocindex);
         // in three cases the type of the value in the struct does not match the expected
         // type returned
@@ -2456,7 +2456,7 @@ struct FunctionEmitter {
             exp->obj("type", &type);
             Ty->EnsureTypeIsComplete(&type);
             Type *ttype = getType(&type)->type;
-            raw = B->CreateLoad(raw->getType()->getPointerElementType(), raw);
+            raw = B->CreateLoad(ttype, raw);
         }
         return raw;
     }

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2792,7 +2792,7 @@ struct FunctionEmitter {
                 Ty->EnsureTypeIsComplete(&type);
                 Type *ttype = getType(&type)->type;
                 Value *v = emitExp(&addr);
-                LoadInst *l = B->CreateLoad(v->getType()->getPointerElementType(), v);
+                LoadInst *l = B->CreateLoad(ttype, v);
                 if (attr.hasfield("alignment")) {
                     int alignment = attr.number("alignment");
                     l->setAlignment(Align(alignment));

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2164,15 +2164,17 @@ struct FunctionEmitter {
         ttype.issigned = ftype->issigned;
         return emitPrimitiveCast(ftype, &ttype, number);
     }
-    Value *emitPointerArith(T_Kind kind, Value *pointer, TType *numTy, Value *number) {
+    Value *emitPointerArith(T_Kind kind, Obj *ptrTy, Value *pointer, TType *numTy,
+                            Value *number) {
+        Obj objTy;
+        Types::PointsToType(ptrTy, &objTy);
+
         number = emitIndex(numTy, 64, number);
         if (kind == T_add) {
-            return B->CreateGEP(pointer->getType()->getPointerElementType(), pointer,
-                                number);
+            return B->CreateGEP(getType(&objTy)->type, pointer, number);
         } else if (kind == T_sub) {
             Value *numNeg = B->CreateNeg(number);
-            return B->CreateGEP(pointer->getType()->getPointerElementType(), pointer,
-                                numNeg);
+            return B->CreateGEP(getType(&objTy)->type, pointer, numNeg);
         } else {
             assert(!"unexpected pointer arith");
             return NULL;
@@ -2220,7 +2222,7 @@ struct FunctionEmitter {
                 return emitPointerSub(t, a, b);
             } else {
                 assert(bt->type->isIntegerTy());
-                return emitPointerArith(kind, a, bt, b);
+                return emitPointerArith(kind, &aot, a, bt, b);
             }
         }
 

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2388,10 +2388,10 @@ struct FunctionEmitter {
         // in all cases we simply bitcast cast the resulting pointer to the expected type
         Obj entryType;
         entry.obj("type", &entryType);
-        if (entry.boolean("inunion") ||
-            isPointerToFunction(addr->getType()->getPointerElementType())) {
+        TType *entryTType = getType(&entryType);
+        if (entry.boolean("inunion") || isPointerToFunction(entryTType->type)) {
             unsigned as = addr->getType()->getPointerAddressSpace();
-            Type *resultType = PointerType::get(getType(&entryType)->type, as);
+            Type *resultType = PointerType::get(entryTType->type, as);
             addr = B->CreateBitCast(addr, resultType);
         }
 

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2180,10 +2180,12 @@ struct FunctionEmitter {
             return NULL;
         }
     }
-    Value *emitPointerSub(TType *t, Value *a, Value *b) {
+    Value *emitPointerSub(Obj *ptrTy, Value *a, Value *b) {
+        Obj objTy;
+        Types::PointsToType(ptrTy, &objTy);
         return B->CreatePtrDiff(
 #if LLVM_VERSION >= 140
-                a->getType()->getPointerElementType(),
+                getType(&objTy)->type,
 #endif
                 a, b);
     }
@@ -2219,7 +2221,7 @@ struct FunctionEmitter {
             Ty->EnsurePointsToCompleteType(&aot);
             if (bt->type->isPointerTy()) {
                 assert(kind == T_sub);
-                return emitPointerSub(t, a, b);
+                return emitPointerSub(&aot, a, b);
             } else {
                 assert(bt->type->isIntegerTy());
                 return emitPointerArith(kind, &aot, a, bt, b);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2362,8 +2362,7 @@ struct FunctionEmitter {
 
         int allocindex = entry.number("allocation");
 
-        Value *addr = CreateConstGEP2_32(B, structPtr,
-                                         getType(structType)->type, 0,
+        Value *addr = CreateConstGEP2_32(B, structPtr, getType(structType)->type, 0,
                                          allocindex);
         // in three cases the type of the value in the struct does not match the expected
         // type returned

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -201,10 +201,10 @@ struct CopyConnectedComponent : public ValueMaterializer {
         } else if (GlobalVariable *GV = dyn_cast<GlobalVariable>(V)) {
             GlobalVariable *newGV = dest->getGlobalVariable(GV->getName(), true);
             if (!newGV || needsFreshlyNamedConstant(GV, newGV)) {
-                newGV = new GlobalVariable(
-                        *dest, GV->getType()->getPointerElementType(), GV->isConstant(),
-                        GV->getLinkage(), NULL, GV->getName(), NULL,
-                        GlobalVariable::NotThreadLocal, GV->getType()->getAddressSpace());
+                newGV = new GlobalVariable(*dest, GV->getValueType(), GV->isConstant(),
+                                           GV->getLinkage(), NULL, GV->getName(), NULL,
+                                           GlobalVariable::NotThreadLocal,
+                                           GV->getType()->getAddressSpace());
                 newGV->copyAttributesFrom(GV);
                 // copyAttributesFrom does not copy comdats
                 newGV->setComdat(GV->getComdat());


### PR DESCRIPTION
This is the first part of the migration toward opaque pointers (#553). Starting with the easy cases, I'm trying to reduce the compiler's reliance on looking up pointee types. But this PR may not get 100% of all the cases.