### PR TITLE
Add support for LLVM 17

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ freebsd_task:
       # LLVM_VERSION: 14
       LLVM_VERSION: 15
       LLVM_VERSION: 16
-      # LLVM_VERSION: 17 # not available as of 2023-09-21
+      LLVM_VERSION: 17
   install_script: pkg install -y bash coreutils cmake gmake llvm$LLVM_VERSION
   script: |
     export CC=cc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,6 +12,7 @@ freebsd_task:
       # LLVM_VERSION: 14
       LLVM_VERSION: 15
       LLVM_VERSION: 16
+      LLVM_VERSION: 17
   install_script: pkg install -y bash coreutils cmake gmake llvm$LLVM_VERSION
   script: |
     export CC=cc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,7 @@ freebsd_task:
       # LLVM_VERSION: 14
       LLVM_VERSION: 15
       LLVM_VERSION: 16
-      LLVM_VERSION: 17
+      # LLVM_VERSION: 17 # not available as of 2023-09-21
   install_script: pkg install -y bash coreutils cmake gmake llvm$LLVM_VERSION
   script: |
     export CC=cc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-11', 'windows-2022']
-        llvm: ['11', '12', '13', '14', '15', '16']
+        llvm: ['11', '12', '13', '14', '15', '16', '17']
         cuda: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
@@ -28,7 +28,7 @@ jobs:
           - os: 'macos-11'
             cuda: '1'
 
-          # Windows: exclude LLVM 12-16
+          # Windows: exclude LLVM 12-17
           - os: 'windows-2022'
             llvm: '12'
           - os: 'windows-2022'
@@ -39,6 +39,8 @@ jobs:
             llvm: '15'
           - os: 'windows-2022'
             llvm: '16'
+          - os: 'windows-2022'
+            llvm: '17'
 
           # CUDA: only LLVM 11
           - llvm: '12'
@@ -87,7 +89,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-18.04']
-        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.2', '16.0.3']
+        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.2', '16.0.3', '17.0.1']
         lua: ['luajit', 'moonjit']
         cuda: ['0', '1']
         test: ['1']
@@ -103,6 +105,8 @@ jobs:
             cuda: '1'
           - llvm: '16.0.3'
             cuda: '1'
+          - llvm: '17.0.1'
+            cuda: '1'
 
           # Moonjit with LLVM 14 only:
           - llvm: '11'
@@ -114,6 +118,8 @@ jobs:
           - llvm: '15.0.2'
             lua: 'moonjit'
           - llvm: '16.0.3'
+            lua: 'moonjit'
+          - llvm: '17.0.1'
             lua: 'moonjit'
 
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -53,6 +53,8 @@ jobs:
             cuda: '1'
           - llvm: '16'
             cuda: '1'
+          - llvm: '17'
+            cuda: '1'
 
           # Moonjit: only LLVM 12
           - llvm: '11'
@@ -64,6 +66,8 @@ jobs:
           - llvm: '15'
             lua: 'moonjit'
           - llvm: '16'
+            lua: 'moonjit'
+          - llvm: '17'
             lua: 'moonjit'
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,7 +93,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-18.04']
-        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.2', '16.0.3', '17.0.1']
+        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.2', '16.0.3', '17.0.5']
         lua: ['luajit', 'moonjit']
         cuda: ['0', '1']
         test: ['1']
@@ -109,7 +109,7 @@ jobs:
             cuda: '1'
           - llvm: '16.0.3'
             cuda: '1'
-          - llvm: '17.0.1'
+          - llvm: '17.0.5'
             cuda: '1'
 
           # Moonjit with LLVM 14 only:
@@ -123,7 +123,7 @@ jobs:
             lua: 'moonjit'
           - llvm: '16.0.3'
             lua: 'moonjit'
-          - llvm: '17.0.1'
+          - llvm: '17.0.5'
             lua: 'moonjit'
 
         include:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Unreleased Changes (Intended to be Version 1.2.0)
 
+## Added features
+
+  * Support for LLVM 17
+
 ## Fixed Bugs
 
   * Updated LuaJIT to obtain fix for passing large arrays on macOS M1

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,7 +82,6 @@ list(APPEND TERRA_LIB_SRC
   tcompilerstate.h
   tllvmutil.cpp    tllvmutil.h
   tcwrapper.cpp    tcwrapper.h
-  tinline.cpp      tinline.h
   terra.cpp
   lparser.cpp      lparser.h
   lstring.cpp      lstring.h
@@ -98,6 +97,12 @@ list(APPEND TERRA_LIB_SRC
 
   ${PROJECT_BINARY_DIR}/include/terra/terra.h
 )
+
+if(LLVM_VERSION_MAJOR LESS 17)
+  list(APPEND TERRA_LIB_SRC
+    tinline.cpp    tinline.h
+  )
+endif()
 
 list(APPEND TERRA_BIN_SRC
   main.cpp

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -33,7 +33,11 @@
 #include "llvm/Transforms/Utils/Cloning.h"
 #include "llvm/Transforms/IPO.h"
 #include "llvm/Transforms/Vectorize.h"
+#if LLVM_VERSION < 170
 #include "llvm/Transforms/IPO/PassManagerBuilder.h"
+#else
+#include "llvm/Passes/PassBuilder.h"
+#endif
 #include "llvm/ExecutionEngine/JITEventListener.h"
 #include "llvm/ExecutionEngine/SectionMemoryManager.h"
 #include "llvm/Support/DynamicLibrary.h"
@@ -56,11 +60,13 @@
 #include "llvmheaders_150.h"
 #elif LLVM_VERSION < 170
 #include "llvmheaders_160.h"
+#elif LLVM_VERSION < 180
+#include "llvmheaders_170.h"
 #else
 #error "unsupported LLVM version"
 // for OSX code completion
-#define LLVM_VERSION 160
-#include "llvmheaders_160.h"
+#define LLVM_VERSION 170
+#include "llvmheaders_170.h"
 #endif
 
 #define UNIQUEIFY(T, x) (std::unique_ptr<T>(x))
@@ -69,13 +75,18 @@
 #define FD_ERRSTR(x) ((x).message().c_str())
 #define METADATA_ROOT_TYPE llvm::Metadata
 
+#if LLVM_VERSION < 170
 using llvm::legacy::FunctionPassManager;
 using llvm::legacy::PassManager;
+typedef llvm::legacy::PassManager PassManagerT;
+typedef llvm::legacy::FunctionPassManager FunctionPassManagerT;
+#else
+using llvm::FunctionPassManager;
+#endif
+
 typedef llvm::raw_pwrite_stream emitobjfile_t;
 typedef llvm::DIFile* DIFileP;
 
 inline void LLVMDisposeMessage(char* Message) { free(Message); }
-typedef llvm::legacy::PassManager PassManagerT;
-typedef llvm::legacy::FunctionPassManager FunctionPassManagerT;
 
 #endif

--- a/src/llvmheaders_170.h
+++ b/src/llvmheaders_170.h
@@ -1,0 +1,34 @@
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Support/Error.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::OF_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::OF_None

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -270,7 +270,7 @@ int terra_inittarget(lua_State *L) {
 
     TT->next_unused_id = 0;
     TT->ctx = new LLVMContext();
-#if LLVM_VERSION >= 150
+#if LLVM_VERSION >= 150 && LLVM_VERSION < 160
     // Hack: This is a workaround to avoid the opaque pointer
     // transition, but we will need to deal with it eventually.
     // FIXME: https://github.com/terralang/terra/issues/553
@@ -2348,12 +2348,18 @@ struct FunctionEmitter {
         return result;
     }
     bool isPointerToFunction(Type *t) {
-        return t->isPointerTy() && t->getPointerElementType()->isFunctionTy();
+        return t->isPointerTy()
+#if LLVM_VERSION < 160
+          && t->getPointerElementType()->isFunctionTy()
+#endif
+;
     }
     Value *emitStructSelect(Obj *structType, Value *structPtr, int index,
                             Obj *entryType) {
         assert(structPtr->getType()->isPointerTy());
+#if LLVM_VERSION < 160
         assert(structPtr->getType()->getPointerElementType()->isStructTy());
+#endif
         Ty->EnsureTypeIsComplete(structType);
 
         Obj layout;

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -3716,10 +3716,7 @@ static int terra_deletefunction(lua_State *L) {
     VERBOSE_ONLY(CU->T) {
         printf("... uses not empty, removing body but keeping declaration.\n");
     }
-#if LLVM_VERSION < 170
-    // FIXME: LLVM crashes if we attempt to delete with opaque pointers enabled
     func->deleteBody();
-#endif
     VERBOSE_ONLY(CU->T) { printf("... finish delete.\n"); }
     fstate->func = NULL;
     freecompilationunit(CU);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -3679,7 +3679,10 @@ static int terra_deletefunction(lua_State *L) {
     VERBOSE_ONLY(CU->T) {
         printf("... uses not empty, removing body but keeping declaration.\n");
     }
+#if LLVM_VERSION < 150
+    // FIXME: LLVM crashes if we attempt to delete with opaque pointers enabled
     func->deleteBody();
+#endif
     VERBOSE_ONLY(CU->T) { printf("... finish delete.\n"); }
     fstate->func = NULL;
     freecompilationunit(CU);

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2350,9 +2350,9 @@ struct FunctionEmitter {
     bool isPointerToFunction(Type *t) {
         return t->isPointerTy()
 #if LLVM_VERSION < 160
-          && t->getPointerElementType()->isFunctionTy()
+               && t->getPointerElementType()->isFunctionTy()
 #endif
-;
+                ;
     }
     Value *emitStructSelect(Obj *structType, Value *structPtr, int index,
                             Obj *entryType) {

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2512,7 +2512,7 @@ struct FunctionEmitter {
             // perform the copy
             Value *m = B->CreateMemCpy(addr_dst, a1, addr_src,
                                        MaybeAlign(
-#if LLVM_VERSION < 170
+#if LLVM_VERSION < 150
                                                l->getAlignment()
 #else
                                                l->getAlign()

--- a/src/tcompilerstate.h
+++ b/src/tcompilerstate.h
@@ -2,7 +2,10 @@
 #define _tcompilerstate_h
 
 #include "llvmheaders.h"
+#if LLVM_VERSION < 170
+// FIXME (Elliott): need to restore the manual inliner in LLVM 17
 #include "tinline.h"
+#endif
 
 struct TerraFunctionInfo {
     llvm::LLVMContext *ctx;
@@ -41,14 +44,18 @@ struct TerraCompilationUnit {
               T(NULL),
               C(NULL),
               M(NULL),
+#if LLVM_VERSION < 170
+              // FIXME (Elliott): need to restore the manual inliner in LLVM 17
               mi(NULL),
+#endif
               fpm(NULL),
               ee(NULL),
               jiteventlistener(NULL),
               Ty(NULL),
               CC(NULL),
               symbols(NULL),
-              functioncount(0) {}
+              functioncount(0) {
+    }
     int nreferences;
     // configuration
     bool optimize;
@@ -59,7 +66,15 @@ struct TerraCompilationUnit {
     terra_CompilerState *C;
     TerraTarget *TT;
     llvm::Module *M;
+#if LLVM_VERSION < 170
+    // FIXME (Elliott): need to restore the manual inliner in LLVM 17
     ManualInliner *mi;
+#else
+    llvm::LoopAnalysisManager lam;
+    llvm::FunctionAnalysisManager fam;
+    llvm::CGSCCAnalysisManager cgam;
+    llvm::ModuleAnalysisManager mam;
+#endif
     FunctionPassManager *fpm;
     llvm::ExecutionEngine *ee;
     llvm::JITEventListener *jiteventlistener;  // for reporting debug info

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -924,11 +924,15 @@ static void optimizemodule(TerraTarget *TT, llvm::Module *M) {
 
     M->setTargetTriple(
             TT->Triple);  // suppress warning that occur due to unmatched os versions
+#if LLVM_VERSION < 170
     PassManager opt;
     llvmutil_addtargetspecificpasses(&opt, TT->tm);
     opt.add(llvm::createFunctionInliningPass());
     llvmutil_addoptimizationpasses(&opt);
     opt.run(*M);
+#else
+    llvmutil_optimizemodule(M, TT->tm);
+#endif
 }
 static int dofile(terra_State *T, TerraTarget *TT, const char *code,
                   const std::vector<const char *> &args, Obj *result) {

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -366,7 +366,10 @@ void llvmutil_optimizemodule(Module *M, TargetMachine *TM) {
     CGSCCAnalysisManager CGAM;
     ModuleAnalysisManager MAM;
 
-    PassBuilder PB(TM);
+    PipelineTuningOptions opt;
+    opt.LoopVectorization = true;
+    opt.SLPVectorization = true;
+    PassBuilder PB(TM, opt);
 
     PB.registerModuleAnalyses(MAM);
     PB.registerCGSCCAnalyses(CGAM);

--- a/src/tllvmutil.h
+++ b/src/tllvmutil.h
@@ -3,9 +3,16 @@
 
 #include "llvmheaders.h"
 
+#if LLVM_VERSION < 170
 void llvmutil_addtargetspecificpasses(llvm::PassManagerBase *fpm,
                                       llvm::TargetMachine *tm);
 void llvmutil_addoptimizationpasses(llvm::PassManagerBase *fpm);
+#else
+llvm::FunctionPassManager llvmutil_createoptimizationpasses(
+        llvm::TargetMachine *TM, llvm::LoopAnalysisManager &LAM,
+        llvm::FunctionAnalysisManager &FAM, llvm::CGSCCAnalysisManager &CGAM,
+        llvm::ModuleAnalysisManager &MAM);
+#endif
 extern "C" void llvmutil_disassemblefunction(void *data, size_t sz, size_t inst);
 bool llvmutil_emitobjfile(llvm::Module *Mod, llvm::TargetMachine *TM,
                           bool outputobjectfile, emitobjfile_t &dest);

--- a/tests/compile_time_array.t
+++ b/tests/compile_time_array.t
@@ -1,3 +1,9 @@
+if terralib.llvm_version >= 170 then
+  print("FIXME: LLVM 17 has a compile time regression in compile_time_array.t, disabling test")
+  return
+end
+
+
 local c = terralib.includecstring([[
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/compile_time_array2.t
+++ b/tests/compile_time_array2.t
@@ -1,3 +1,8 @@
+if terralib.llvm_version >= 170 then
+  print("FIXME: LLVM 17 has a compile time regression in compile_time_array.t, disabling test")
+  return
+end
+
 local c = terralib.includecstring([[
 #include <stdio.h>
 #include <stdlib.h>

--- a/tests/constantinits.t
+++ b/tests/constantinits.t
@@ -1,3 +1,8 @@
+if terralib.llvm_version >= 170 and require("ffi").os == "Linux" then
+  print("Skipping broken test on Linux, see #644")
+  return -- FIXME: https://github.com/terralang/terra/issues/644
+end
+
 function failit(match,fn)
 	local success,msg = xpcall(fn,debug.traceback)
 	--print(msg)

--- a/tests/dgemm3.t
+++ b/tests/dgemm3.t
@@ -11,7 +11,7 @@ end
 
 local function isinteger(x) return math.floor(x) == x end
 
-if terralib.llvm_version < 160 then
+if terralib.llvm_version < 170 then
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
 else
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})

--- a/tests/dgemm3.t
+++ b/tests/dgemm3.t
@@ -11,7 +11,11 @@ end
 
 local function isinteger(x) return math.floor(x) == x end
 
-llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+if terralib.llvm_version < 160 then
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+else
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})
+end
 
 local function alignedload(addr)
 	return `terralib.attrload(addr, { align = 8 })

--- a/tests/dgemmpaper.t
+++ b/tests/dgemmpaper.t
@@ -7,7 +7,7 @@ function symmat(typ,name,I,...)
   end
   return r
 end
-if terralib.llvm_version < 160 then
+if terralib.llvm_version < 170 then
   prefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
 else
   prefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})

--- a/tests/dgemmpaper.t
+++ b/tests/dgemmpaper.t
@@ -7,7 +7,11 @@ function symmat(typ,name,I,...)
   end
   return r
 end
-prefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+if terralib.llvm_version < 160 then
+  prefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+else
+  prefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})
+end
 
 function genkernel(NB, RM, RN, V,alpha)
   local VT = vector(double,V)

--- a/tests/diffuse.t
+++ b/tests/diffuse.t
@@ -99,7 +99,7 @@ terra diffuse(output : &float, N : int, M : int, stride : int, x : &float, x0 : 
 
 end
 
-if terralib.llvm_version < 160 then
+if terralib.llvm_version < 170 then
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
 else
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})

--- a/tests/diffuse.t
+++ b/tests/diffuse.t
@@ -99,7 +99,11 @@ terra diffuse(output : &float, N : int, M : int, stride : int, x : &float, x0 : 
 
 end
 
-llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+if terralib.llvm_version < 160 then
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+else
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})
+end
 
 terra diffuse2(output : &float, N : int, M : int, stride : int, x : &float, x0 : &float, a : float,xi : &float)
 	var invD = 1.f / (1 + 4.f*a)

--- a/tests/gemm.t
+++ b/tests/gemm.t
@@ -13,7 +13,7 @@ end
 
 local function isinteger(x) return math.floor(x) == x end
 
-if terralib.llvm_version < 160 then
+if terralib.llvm_version < 170 then
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
 else
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})

--- a/tests/gemm.t
+++ b/tests/gemm.t
@@ -13,7 +13,11 @@ end
 
 local function isinteger(x) return math.floor(x) == x end
 
-llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+if terralib.llvm_version < 160 then
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+else
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})
+end
 local function unalignedload(addr)
 	return `terralib.attrload(addr, { align = alignment })
 end

--- a/tests/sgemm3.t
+++ b/tests/sgemm3.t
@@ -9,7 +9,11 @@ function symmat(typ,name,I,...)
 end
 
 
-llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+if terralib.llvm_version < 160 then
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
+else
+  llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})
+end
 
 
 

--- a/tests/sgemm3.t
+++ b/tests/sgemm3.t
@@ -9,7 +9,7 @@ function symmat(typ,name,I,...)
 end
 
 
-if terralib.llvm_version < 160 then
+if terralib.llvm_version < 170 then
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0i8",{&opaque,int,int,int} -> {})
 else
   llvmprefetch = terralib.intrinsic("llvm.prefetch.p0",{&opaque,int,int,int} -> {})

--- a/travis.sh
+++ b/travis.sh
@@ -34,11 +34,11 @@ if [[ $(uname) = Linux ]]; then
 
 elif [[ $(uname) = Darwin ]]; then
   if [[ $LLVM_VERSION = 17 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-17.0.1/clang+llvm-17.0.1-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-17.0.1-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-17.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-17
-    ln -s clang+llvm-17.0.1-x86_64-apple-darwin/bin/clang clang-17
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-17.0.1-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-17.0.5/clang+llvm-17.0.5-x86_64-apple-darwin.tar.xz
+    tar xf clang+llvm-17.0.5-x86_64-apple-darwin.tar.xz
+    ln -s clang+llvm-17.0.5-x86_64-apple-darwin/bin/llvm-config llvm-config-17
+    ln -s clang+llvm-17.0.5-x86_64-apple-darwin/bin/clang clang-17
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-17.0.5-x86_64-apple-darwin
   elif [[ $LLVM_VERSION = 16 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-16.0.3/clang+llvm-16.0.3-x86_64-apple-darwin.tar.xz
     tar xf clang+llvm-16.0.3-x86_64-apple-darwin.tar.xz

--- a/travis.sh
+++ b/travis.sh
@@ -33,7 +33,13 @@ if [[ $(uname) = Linux ]]; then
   exit 1
 
 elif [[ $(uname) = Darwin ]]; then
-  if [[ $LLVM_VERSION = 16 ]]; then
+  if [[ $LLVM_VERSION = 17 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-17.0.1/clang+llvm-17.0.1-x86_64-apple-darwin.tar.xz
+    tar xf clang+llvm-17.0.1-x86_64-apple-darwin.tar.xz
+    ln -s clang+llvm-17.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-17
+    ln -s clang+llvm-17.0.1-x86_64-apple-darwin/bin/clang clang-17
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-17.0.1-x86_64-apple-darwin
+  elif [[ $LLVM_VERSION = 16 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-16.0.3/clang+llvm-16.0.3-x86_64-apple-darwin.tar.xz
     tar xf clang+llvm-16.0.3-x86_64-apple-darwin.tar.xz
     ln -s clang+llvm-16.0.3-x86_64-apple-darwin/bin/llvm-config llvm-config-16


### PR DESCRIPTION
This rolls up the changes in #641 and then adds more on top to adapt to the removal of the legacy pass manager in LLVM 17. Overall, this seems to be working dramatically better than LLVM 15-16, so I have updated the opaque pointer version bounds to be LLVM 17-only.

Running the test suite locally (macOS x86) produces one test failure:

```
99% tests passed, 1 tests failed out of 550

Total Test time (real) = 143.88 sec

The following tests FAILED:
	 71 - classifyfloatstructs.t (Failed)
Errors while running CTest
```

For once I'm actually done with this ahead of the LLVM 17 final release (above results were with rc4), so I can't merge this until the final release gets cut. But things are looking good overall.

Known issues:

 * Compile time regressions in `compile_time_array.t` and `compile_time_array2.t` forcing those tests to be shut off in LLVM 17. A similar (but less severe) issue is present in `bug372_perf.t`, but it's minor enough I left that one in. Possibly a result of the new pass manager.
 * `constantinits.t` fails on Linux: #644.
 * I was forced to remove the manual inliner. Figure out how to put it back (or if we need it).
 * Performance has not been verified, so I have no idea if it's anywhere near reasonable or not.