### PR TITLE
Support for SPIR-V code generation

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -2828,7 +2828,12 @@ struct FunctionEmitter {
 #if LLVM_VERSION < 170
                         return B->CreateBitCast(v, toT->type);
 #else
-                        return v;
+                        if (fromT->type->getPointerAddressSpace() !=
+                            toT->type->getPointerAddressSpace()) {
+                            return B->CreateAddrSpaceCast(v, toT->type);
+                        } else {
+                            return v;
+                        }
 #endif
                     } else {
                         assert(toT->type->isIntegerTy());

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -808,20 +808,26 @@ struct CCallingConv {
                 ppc64_int_limit = 8;
                 ppc64_count_used = true;
             } break;
+#if LLVM_VERSION >= 150
             case Triple::ArchType::spirv32:
             case Triple::ArchType::spirv64: {
                 spirv_cconv = true;
             } break;
+#endif
             case Triple::ArchType::wasm32:
             case Triple::ArchType::wasm64: {
                 wasm_cconv = true;
             } break;
+            default:
+                break;
         }
 
         switch (Triple.getOS()) {
             case Triple::OSType::Win32: {
                 return_empty_struct_as_void = true;
             } break;
+            default:
+                break;
         }
     }
 

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -811,6 +811,7 @@ struct CCallingConv {
 #if LLVM_VERSION >= 150
             case Triple::ArchType::spirv32:
             case Triple::ArchType::spirv64: {
+                return_empty_struct_as_void = true;
                 spirv_cconv = true;
             } break;
 #endif
@@ -1147,7 +1148,7 @@ struct CCallingConv {
         int zero = 0;
         info->returntype = ClassifyArgument(&returntype, &zero, &zero, true);
 
-        if (return_empty_struct_as_void || cconv == CallingConv::SPIR_KERNEL) {
+        if (return_empty_struct_as_void) {
             // windows classifies empty structs as pass by pointer, but we need a return
             // value of unit (an empty tuple) to be translated to void. So if it is unit,
             // force the return value to be void by overriding the normal classification

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -2455,15 +2455,15 @@ function typecheck(topexp,luaenv,simultaneousdefinitions)
         end
         local function ascompletepointer(exp) --convert pointer like things into pointers to _complete_ types
             exp.type.type:tcomplete(exp)
-            return (insertcast(exp,terra.types.pointer(exp.type.type))) --parens are to truncate to 1 argument
+            return (insertcast(exp,terra.types.pointer(exp.type.type, exp.type.addressspace))) --parens are to truncate to 1 argument
         end
         -- subtracting 2 pointers
         if  pointerlike(l.type) and pointerlike(r.type) and l.type.type == r.type.type and e.operator == tokens["-"] then
             return e:copy { operands = List {ascompletepointer(l),ascompletepointer(r)} }:withtype(terra.types.ptrdiff)
         elseif pointerlike(l.type) and r.type:isintegral() then -- adding or subtracting a int to a pointer
-            return e:copy {operands = List {ascompletepointer(l),r} }:withtype(terra.types.pointer(l.type.type))
+            return e:copy {operands = List {ascompletepointer(l),r} }:withtype(terra.types.pointer(l.type.type, l.type.addressspace))
         elseif l.type:isintegral() and pointerlike(r.type) then
-            return e:copy {operands = List {ascompletepointer(r),l} }:withtype(terra.types.pointer(r.type.type))
+            return e:copy {operands = List {ascompletepointer(r),l} }:withtype(terra.types.pointer(r.type.type, r.type.addressspace))
         else
             return meetbinary(e,"isarithmeticorvector",l,r)
         end

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -1277,7 +1277,12 @@ do
                 if status then return r end
             end
             return self.name
-        elseif self:ispointer() then return "&"..tostring(self.type)
+        elseif self:ispointer() then
+            if not self.addressspace or self.addressspace == 0 then
+                return "&"..tostring(self.type)
+            else
+                return "pointer("..tostring(self.type)..","..tostring(self.addressspace)..")"
+            end
         elseif self:isvector() then return "vector("..tostring(self.type)..","..tostring(self.N)..")"
         elseif self:isfunction() then return mkstring(self.parameters,"{",",",self.isvararg and " ...}" or "}").." -> "..tostring(self.returntype)
         elseif self:isarray() then

--- a/tests/addressspace.t
+++ b/tests/addressspace.t
@@ -1,0 +1,26 @@
+-- Tests of pointers with address spaces.
+
+-- The exact meaning of this depends on the target, but at least basic
+-- code compilation should work.
+
+local function ptr1(ty)
+  -- A pointer in address space 1.
+  return terralib.types.pointer(ty, 1)
+end
+
+terra test(x : &int, y : ptr1(int))
+  -- Should be able to do math on pointers with non-zero address spaces:
+  var a = [ptr1(int8)](y)
+  var b = a + 8
+  var c  = [ptr1(int)](b)
+  var d = c - y
+  y = c
+
+  -- Casts should work:
+  y = [ptr1(int)](x)
+  x = [&int](y)
+
+  return d
+end
+test:compile()
+print(test)


### PR DESCRIPTION
This is a new approach to the work we originally began in #469. Since the last time we put effort into this, Intel integrated a SPIR-V target directly into LLVM itself. The new target was first available in LLVM 15 and has improved dramatically over the last few releases.

Therefore, this puts us on a much better footing than #469 which fundamentally relied on some infrastructure in Clang (because the corresponding LLVM target did not actually exist and it was faked entirely on the Clang side).

I'm currently in the process of verifying that this new SPIR-V support works and is able to generate code that is compatible with, say, OpenCL.