### PR TITLE
RAII

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /build
+/cmake-build-debug
 /docs/_site
 /docs/_vendor
 /install
@@ -18,6 +19,13 @@
 /tests/dynlib
 /tests/dynlib.exe
 /tests/not_bc
+/tests/class2
+/tests/inline_c.exe
+/tests/objc
+/tests/objc2
+/tests/stdio.exe
+
+/.idea
 
 *.bc
 *.ll

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -3692,11 +3692,11 @@ function terra.includecstring(code,cargs,target)
     	args:insert(path)
     end
     -- Obey the SDKROOT variable on macOS to match Clang behavior.
-    local sdkroot = os.getenv("SDKROOT")
-    if sdkroot then
-      args:insert("-isysroot")
-      args:insert(sdkroot)
-    end
+    --local sdkroot = os.getenv("SDKROOT")
+    --if sdkroot then
+    --  args:insert("-isysroot")
+    --  args:insert(sdkroot)
+    --end
     -- Set GNU C version to match value set by Clang: https://github.com/llvm/llvm-project/blob/f77c948d56b09b839262e258af5c6ad701e5b168/clang/lib/Driver/ToolChains/Clang.cpp#L5750-L5753
     if ffi.os ~= "Windows" and terralib.llvm_version >= 100 then
       args:insert("-fgnuc-version=4.2.1")

--- a/tests/raii-unique_ptr.t
+++ b/tests/raii-unique_ptr.t
@@ -1,0 +1,95 @@
+local std = {}
+std.io = terralib.includec("stdio.h")
+std.lib = terralib.includec("stdlib.h")
+
+local function printtestheader(s)
+    print()
+    print("===========================")
+    print(s)
+    print("===========================")
+end
+
+struct A{
+    data : &int
+    heap : bool
+}
+
+A.metamethods.__init = terra(self : &A)
+    std.io.printf("__init: initializing object. start.\n")
+    self.data = nil         -- initialize data pointer to nil
+    self.heap = false       --flag to denote heap resource
+    std.io.printf("__init: initializing object. return.\n")
+end
+
+A.metamethods.__dtor = terra(self : &A)
+    std.io.printf("__dtor: calling destructor. start\n")
+    defer std.io.printf("__dtor: calling destructor. return\n")
+    if self.heap then
+        std.lib.free(self.data)
+        self.data = nil
+        self.heap = false
+        std.io.printf("__dtor: freed memory.\n")
+    end
+end
+
+A.metamethods.__copy = terralib.overloadedfunction("__copy")
+A.metamethods.__copy:adddefinition(
+terra(from : &A, to : &A)
+    std.io.printf("__copy: moving resources {&A, &A} -> {}.\n")
+    to.data = from.data
+    to.heap = from.heap
+    from.data = nil
+    from.heap = false
+end)
+A.metamethods.__copy:adddefinition(
+terra(from : &int, to : &A)
+    std.io.printf("__copy: assignment {&int, &A} -> {}.\n")
+    to.data = from
+    to.heap = false --not known at compile time
+end)
+
+--dereference ptr
+terra A.methods.getvalue(self : &A)
+    return @self.data
+end
+
+terra A.methods.setvalue(self : &A, value : int)
+    @self.data = value
+end
+
+--heap memory allocation
+terra A.methods.allocate(self : &A)
+    std.io.printf("allocate: allocating memory. start\n")
+    defer std.io.printf("allocate: allocating memory. return.\n")
+    self.data = [&int](std.lib.malloc(sizeof(int)))
+    self.heap = true
+end
+
+terra testdereference()
+    var ptr : A
+    ptr:allocate()
+    ptr:setvalue(3)
+    return ptr:getvalue()
+end
+
+terra returnheapresource()
+    var ptr : A
+    ptr:allocate()
+    ptr:setvalue(3)
+    return ptr
+end
+
+terra testgetptr()
+    var ptr = returnheapresource()
+    return ptr:getvalue()
+end
+
+local test = require "test"
+
+printtestheader("raii-unique_ptr.t: test return ptr value from function before resource is deleted")
+test.eq(testdereference(), 3)
+
+printtestheader("raii-unique_ptr.t: test return heap resource from function")
+test.eq(testgetptr(), 3)
+
+

--- a/tests/raii.t
+++ b/tests/raii.t
@@ -1,0 +1,106 @@
+local std = {}
+std.io = terralib.includec("stdio.h")
+
+local function printtestheader(s)
+    print()
+    print("===========================")
+    print(s)
+    print("===========================")
+end
+
+struct A{
+    data : int
+}
+
+A.metamethods.__init = terra(self : &A)
+    std.io.printf("__init: calling initializer.\n")
+    self.data = 1
+end
+
+A.metamethods.__dtor = terra(self : &A)
+    std.io.printf("__dtor: calling destructor.\n")
+    self.data = -1
+end
+
+A.metamethods.__copy = terralib.overloadedfunction("__copy")
+A.metamethods.__copy:adddefinition(terra(from : &A, to : &A)
+    std.io.printf("__copy: calling copy assignment {&A, &A} -> {}.\n")
+    to.data = from.data + 10
+end)
+A.metamethods.__copy:adddefinition(terra(from : int, to : &A)
+    std.io.printf("__copy: calling copy assignment {int, &A} -> {}.\n")
+    to.data = from
+end)
+A.metamethods.__copy:adddefinition(terra(from : &A, to : &int)
+    std.io.printf("__copy: calling copy assignment {&A, &int} -> {}.\n")
+    @to = from.data
+end)
+
+
+terra testinit()
+    var a : A
+    return a.data
+end
+
+terra testdtor()
+    var x : &int
+    do
+        var a : A
+        x = &a.data
+    end
+    return @x
+end
+
+terra testcopyconstruction()
+    var a : A
+    var b = a
+    return b.data
+end
+
+terra testcopyassignment()
+    var a : A
+    a.data = 2
+    var b : A
+    b = a
+    return b.data
+end
+
+terra testcopyassignment1()
+    var a : A
+    a = 3
+    return a.data
+end
+
+terra testcopyassignment2()
+    var a : A
+    var x : int
+    a.data = 5
+    x = a
+    return x
+end
+
+local test = require "test"
+
+--test if __init is called on object initialization to set 'a.data = 1'
+printtestheader("raii.t - testing __init metamethod")
+test.eq(testinit(), 1)
+
+--test if __dtor is called at the end of the scope to set 'a.data = -1'
+printtestheader("raii.t - testing __dtor metamethod")
+test.eq(testdtor(), -1)
+
+--test if __copy is called in construction 'var b = a'
+printtestheader("raii.t - testing __copy metamethod in copy-construction")
+test.eq(testcopyconstruction(), 11)
+
+--test if __copy is called in an assignment 'b = a'
+printtestheader("raii.t - testing __copy metamethod in copy-assignment")
+test.eq(testcopyassignment(), 12)
+
+--test if __copy is called in an assignment 'a = 3'
+printtestheader("raii.t - testing __copy metamethod in copy-assignment from integer to struct.")
+test.eq(testcopyassignment1(), 3)
+
+--test if __copy is called in an assignment 'x = a' for integer x
+printtestheader("raii.t - testing __copy metamethod in copy-assignment from struct to integer.")
+test.eq(testcopyassignment2(), 5)


### PR DESCRIPTION
I've closed #658 [(https://github.com/terralang/terra/pull/658)] and reopened it here in order to get a clean git commit history. This second attempt is implemented from scratch.

I'll summarize the pull request and the revised design:

**Objective:** The point of the contribution is to add some metamethods to enable RAII in order to implement smart containers and smart pointers, like `std::string`, `std::vector` and `std::unique_ptr`, `std::shared_ptr`, `boost:offset_ptr` in C++.

The design does not introduce any breaking changes. No new keywords are introduced. Heap resources are acquired and released using the regular C stdlib functions such malloc and free, leaving memory allocation in the hands of the programmer.

**New metamethods:** The following metamethods are implemented:
1. `__init(self : &A)`
2. `__dtor(self : &A)`
3. `__copy(from : &A, to : &B)`

If implemented, these methods are inserted judiciously during the type checking phase, implemented in terralib.lua. All these metamethods can be implemented as macro's or as terra functions.

I will explain the metamethods in some more depth:

A **managed type** is one that implements the above metamethods. In the following I assume `struct A` is a managed type.
- `__init` is used to initialize managed variables:
```
    A.metamethods.__init(self : &A)
```
The implementation checks for an `__init` metamethod in any defvar statement: `var a : A` and applies it if it exists.
- `__dtor` can be used to free heap memory
```
    A.metamethods.__dtor(self : &A)
``` 
The implementation adds a deferred call to `__dtor` (right before any return statements) for any variable local to the current scope that is not returned. Hence, it is tied to the lifetime of the object. `__dtor` is also called before any copy-assignment.
- `__copy` enables specialized copy-assignment and, combined with `__init`, copy construction.  `__copy` takes two arguments, which can be different, as long as one of them is a managed type, e.g.
```
    A.metamethods.__copy(from : &A, to : &B)
```
and / or
```
    A.metamethods.__copy(from : &B, to : &A)
```
`__copy` can be an overloaded function. In object construction, in case of `b` below, `__copy` is combined with `__init` to perform copy construction: 
```
    var a : A
    a.data = ...
    var b = a
```
which is the same as writing
```
    var a : A
    a.data = ...
    var b : A
    b = a
```

I think the above covers all the use cases of smart containers and pointers in c++. I still need to make the metamethods work properly in the case of compositional API's, like  mentioned in #658 (`vector(vector(int))` or a `vector(string)`).

First, let's verify that the CI is passing. Over the next few days I'll add some more tests to test managed data-structures.