### PR TITLE
Update Nix build to use LLVM 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,7 +242,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        nixpkgs: ['unstable', '23.05']
+        nixpkgs: ['unstable', '24.05']
         cuda: ['false', 'true']
     steps:
       - uses: actions/checkout@v2.3.4

--- a/default.nix
+++ b/default.nix
@@ -5,7 +5,7 @@
 
 let
 
-  llvmPackages = pkgs.llvmPackages_11;
+  llvmPackages = pkgs.llvmPackages_13;
   stdenv = llvmPackages.stdenv;
   cuda = if cudaPackages ? cudatoolkit_11 then [
            cudaPackages.cudatoolkit_11
@@ -89,7 +89,8 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A low-level counterpart to Lua";
     homepage = "http://terralang.org/";
-    platforms = platforms.x86_64 ++ platforms.aarch64;
+    # Note: Nix has removed LLVM 11, required for Linux AArch64
+    platforms = platforms.x86_64 ++ platforms.darwin; # ++ platforms.aarch64;
     maintainers = with maintainers; [ jb55 thoughtpolice ];
     license = licenses.mit;
   };

--- a/default.nix
+++ b/default.nix
@@ -1,7 +1,8 @@
 { pkgs ? import <nixpkgs> { }, lib ? pkgs.lib
 , fetchFromGitHub ? pkgs.fetchFromGitHub, ncurses ? pkgs.ncurses
 , cmake ? pkgs.cmake, libxml2 ? pkgs.libxml2, symlinkJoin ? pkgs.symlinkJoin
-, cudaPackages ? pkgs.cudaPackages, enableCUDA ? false }:
+, cudaPackages ? pkgs.cudaPackages, enableCUDA ? false
+, libpfm ? pkgs.libpfm }:
 
 let
 
@@ -48,7 +49,9 @@ in stdenv.mkDerivation rec {
   src = ./.;
 
   nativeBuildInputs = [ cmake ];
-  buildInputs = [ llvmMerged ncurses libxml2 ] ++ lib.optionals enableCUDA cuda;
+  buildInputs = [ llvmMerged ncurses libxml2 ]
+    ++ lib.optionals enableCUDA cuda
+    ++ lib.optional (!stdenv.isDarwin) libpfm;
 
   cmakeFlags = [
     "-DHAS_TERRA_VERSION=0"


### PR DESCRIPTION
Nix has removed LLVM 11 so we need to move to a newer version.

This removes Linux AArch64 support in Nix because that still requires LLVM 11. You can downgrade Nix to an older version to get the LLVM 11 package to restore this support, but we will not be maintaining it here.