### PR TITLE
Switch to snprintf throughout codebase

### DIFF
--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -961,14 +961,14 @@ static void doquote(LexState *ls, int isexp) {
 }
 
 // buf should be at least 128 chars
-static void number_type(LexState *ls, int flags, char *buf) {
+static void number_type(LexState *ls, int flags, char *buf, size_t bufsiz) {
     if (ls->in_terra) {
         if (flags & F_ISINTEGER) {
             const char *sign = (flags & F_ISUNSIGNED) ? "u" : "";
             const char *sz = (flags & F_IS8BYTES) ? "64" : "";
-            sprintf(buf, "%sint%s", sign, sz);
+            snprintf(buf, bufsiz, "%sint%s", sign, sz);
         } else {
-            sprintf(buf, "%s", (flags & F_IS8BYTES) ? "double" : "float");
+            snprintf(buf, bufsiz, "%s", (flags & F_IS8BYTES) ? "double" : "float");
         }
     }
 }
@@ -997,11 +997,11 @@ static void simpleexp(LexState *ls) {
         case TK_NUMBER: {
             char buf[128];
             int flags = ls->t.seminfo.flags;
-            number_type(ls, flags, &buf[0]);
+            number_type(ls, flags, &buf[0], sizeof(buf));
             if (flags & F_ISINTEGER) {
                 push_integer(ls, ls->t.seminfo.i);
                 push_literal(ls, buf);
-                sprintf(buf, "%" PRIu64, ls->t.seminfo.i);
+                snprintf(buf, sizeof(buf), "%" PRIu64, ls->t.seminfo.i);
                 push_string(ls, buf);
                 add_field(ls, -2, "stringvalue");
 
@@ -2053,7 +2053,7 @@ static void converttokentolua(LexState *ls, Token *t) {
             lua_pushstring(ls->L, "<number>");
             lua_setfield(ls->L, -2, "type");
             int flags = t->seminfo.flags;
-            number_type(ls, flags, &buf[0]);
+            number_type(ls, flags, &buf[0], sizeof(buf));
             push_type(ls, buf);
             lua_setfield(ls->L, -2, "valuetype");
             if (flags & F_IS8BYTES && flags & F_ISINTEGER) {

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -99,7 +99,7 @@ public:
             std::string declstr;
             if (it->isAnonymousStructOrUnion()) {
                 char buf[32];
-                sprintf(buf, "_%d", anonname++);
+                snprintf(buf, sizeof(buf), "_%d", anonname++);
                 declstr = buf;
             } else {
                 declstr = declname.getAsString();

--- a/src/terra.cpp
+++ b/src/terra.cpp
@@ -572,8 +572,9 @@ int terra_loadfile(lua_State *L, const char *file) {
         if (c == '\n') ungetc(c, ctx.fp); /* keep line count accurate */
     }
     if (file) {
-        char *name = (char *)malloc(strlen(file) + 2);
-        sprintf(name, "@%s", file);
+        size_t name_size = strlen(file) + 2;
+        char *name = (char *)malloc(name_size);
+        snprintf(name, name_size, "@%s", file);
         int r = terra_load(L, reader_file, &ctx, name);
         free(name);
         fclose(ctx.fp);


### PR DESCRIPTION
I've audited these, and I don't think they would have caused issues, but `sprintf` is still bad all around so better to avoid it.