### PR TITLE
Update release packages to use LLVM 18

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,16 +174,6 @@ jobs:
             static: '1'
             test: '1'
 
-          # LLVM 18 on Ubuntu 24.04
-          - distro: 'ubuntu-24.04'
-            llvm: '18'
-            lua: 'luajit'
-            cuda: '0'
-            variant: 'package'
-            slib: '1'
-            static: '1'
-            test: '1'
-
           # LLVM 14, no-slib/no-static, Ubuntu 22.04
           - distro: 'ubuntu-22.04'
             llvm: '14'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,7 @@ jobs:
     name: Check Format
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: ./travis.sh
         env:
           CHECK_CLANG_FORMAT: 1
@@ -76,7 +76,7 @@ jobs:
           - llvm: '18'
             lua: 'moonjit'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: ./travis.sh
         shell: bash
         env:
@@ -87,7 +87,7 @@ jobs:
           SLIB_INCLUDE_LLVM: 1
           SLIB_INCLUDE_LUAJIT: 1
           TERRA_LUA: ${{ matrix.lua }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: terra-${{ matrix.os }}-x86_64-llvm-${{ matrix.llvm }}
           path: |
@@ -192,7 +192,7 @@ jobs:
           #   static: '0'
           #   test: '1'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: ./travis.sh
         env:
           DOCKER_DISTRO: ${{ matrix.distro }}
@@ -220,7 +220,7 @@ jobs:
           - arch: 'ppc64le'
             llvm: '11.1.0'
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: ./travis.sh
         env:
           DOCKER_DISTRO: ${{ matrix.distro }}
@@ -229,7 +229,7 @@ jobs:
           DOCKER_CUDA: ${{ matrix.cuda }}
           DOCKER_VARIANT: ${{ matrix.variant }}
           DOCKER_TEST: ${{ matrix.test }}
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: docker-${{ matrix.distro }}-${{ matrix.arch }}-llvm-${{ matrix.llvm }}
           path: |
@@ -239,9 +239,9 @@ jobs:
     name: Compatibility Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04 24.04" "" 18.1.7 luajit prebuilt 2
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
           name: docker-ubuntu-18.04-x86_64-llvm-18
           path: |
@@ -255,7 +255,7 @@ jobs:
         nixpkgs: ['unstable', '24.05']
         cuda: ['false', 'true']
     steps:
-      - uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v13
         with:
           nix_path: nixpkgs=channel:nixos-${{ matrix.nixpkgs }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,6 +174,16 @@ jobs:
             static: '1'
             test: '1'
 
+          # LLVM 18 on Ubuntu 24.04
+          - distro: 'ubuntu-24.04'
+            llvm: '18'
+            lua: 'luajit'
+            cuda: '0'
+            variant: 'package'
+            slib: '1'
+            static: '1'
+            test: '1'
+
           # LLVM 14, no-slib/no-static, Ubuntu 22.04
           - distro: 'ubuntu-22.04'
             llvm: '14'
@@ -240,10 +250,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04" "" 13.0.1 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04" "" 18.1.7 luajit prebuilt 2
       - uses: actions/upload-artifact@v2
         with:
-          name: docker-ubuntu-18.04-x86_64-llvm-13
+          name: docker-ubuntu-18.04-x86_64-llvm-18
           path: |
             terra-*.tar.xz
             terra-*.7z

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -240,7 +240,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04" "" 18.1.7 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04 24.04" "" 18.1.7 luajit prebuilt 2
       - uses: actions/upload-artifact@v2
         with:
           name: docker-ubuntu-18.04-x86_64-llvm-18

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -124,24 +124,24 @@ If the binary releases are not appropriate, then you can also build Terra from s
 On recent versions of Ubuntu, you can get these dependencies with:
 
 ```
-sudo apt-get install build-essential cmake git llvm-13-dev libclang-13-dev clang-13 libmlir-13-dev libedit-dev libncurses5-dev zlib1g-dev libpfm4-dev
+sudo apt-get install build-essential cmake git llvm-18-dev libclang-18-dev clang-18 libmlir-18-dev libedit-dev libncurses5-dev zlib1g-dev libpfm4-dev
 ```
 
 On macOS with Homebrew, the following should be sufficient:
 
 ```
-brew install cmake llvm@13
+brew install cmake llvm@18
 ```
 
 On FreeBSD, use:
 
 ```
-pkg install -y cmake llvm13
+pkg install -y cmake gmake llvm18
 ```
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **13** for most platforms, except Windows (x86) and Linux (ARM) where LLVM 11 is required. The following versions are also supported:
+The current recommended version of LLVM is **18** for most platforms, except Windows (x86) and Linux (ARM) where LLVM 11 is required. The following versions are also supported:
 
 | Version |         Linux |         macOS |       FreeBSD |       Windows |   NVIDIA/CUDA | AMD/HIP \*     | Intel/SPIRV \*\* | Notes |
 | ------- | ------------- | ------------- | ------------- | ------------- | ------------- | -------------- | ---------------- | ----- |
@@ -149,10 +149,10 @@ The current recommended version of LLVM is **13** for most platforms, except Win
 |      12 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |                |                  | |
 |      13 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |                  | |
 |      14 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |                  | |
-|      15 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |                  | |
-|      16 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |                  | |
+|      15 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |   :yellow_heart: | |
+|      16 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |   :yellow_heart: | |
 |      17 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :yellow_heart: |    :green_heart: | |
-|      18 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: | :green_heart:  |    :green_heart: | |
+|      18 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
 
 \* AMD GPU support is currently experimental. LLVM 18 is **strongly** recommended.
 

--- a/travis.sh
+++ b/travis.sh
@@ -178,7 +178,7 @@ if [[ $(uname) != Darwin ]]; then
 fi
 
 # Only deploy builds with LLVM 13 (macOS) and 11 (Windows).
-if [[ (( $(uname) == Darwin && $LLVM_VERSION = 13 ) || ( $(uname) == MINGW* && $LLVM_VERSION = 11 && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
+if [[ (( $(uname) == Darwin && $LLVM_VERSION = 18 ) || ( $(uname) == MINGW* && $LLVM_VERSION = 11 && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
   RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-`uname -m`-`git rev-parse --short HEAD`
   mv install $RELEASE_NAME
   if [[ $(uname) = MINGW* ]]; then


### PR DESCRIPTION
 * Update Linux compat test to use LLVM 18 and test on Ubuntu 24.04
 * ~Add Ubuntu 24.04 package test for LLVM 18~ (not working, we'll have to add this later)
 * Update macOS to release LLVM 18
 * Update README instructions and guidance