### PR TITLE
Run GitHub Actions CI on macOS M1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['macos-12', 'windows-2022']
+        # Note: macOS 12 runs on x86 hardware, and 14 runs on M1 hardware
+        os: ['macos-12', 'macos-14', 'windows-2022']
         llvm: ['11', '12', '13', '14', '15', '16', '17', '18']
         cuda: ['0', '1']
         lua: ['luajit', 'moonjit']
@@ -27,6 +28,12 @@ jobs:
           # macOS: exclude cuda
           - os: 'macos-12'
             cuda: '1'
+          - os: 'macos-14'
+            cuda: '1'
+
+          # macOS 14: exclude Moonjit (M1 requires LuaJIT)
+          - os: 'macos-14'
+            lua: 'moonjit'
 
           # Windows: exclude LLVM 12-18
           - os: 'windows-2022'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           - os: 'macos-14'
             lua: 'moonjit'
 
-          # macOS 14: exclude LLVM 11-17
+          # macOS 14: exclude LLVM 11-15,17
           - os: 'macos-14'
             llvm: '11'
           - os: 'macos-14'
@@ -46,8 +46,6 @@ jobs:
             llvm: '14'
           - os: 'macos-14'
             llvm: '15'
-          - os: 'macos-14'
-            llvm: '16'
           - os: 'macos-14'
             llvm: '17'
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,22 @@ jobs:
           - os: 'macos-14'
             lua: 'moonjit'
 
+          # macOS 14: exclude LLVM 11-17
+          - os: 'macos-14'
+            llvm: '11'
+          - os: 'macos-14'
+            llvm: '12'
+          - os: 'macos-14'
+            llvm: '13'
+          - os: 'macos-14'
+            llvm: '14'
+          - os: 'macos-14'
+            llvm: '15'
+          - os: 'macos-14'
+            llvm: '16'
+          - os: 'macos-14'
+            llvm: '17'
+
           # Windows: exclude LLVM 12-18
           - os: 'windows-2022'
             llvm: '12'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
           - os: 'macos-14'
             lua: 'moonjit'
 
-          # macOS 14: exclude LLVM 11-15,17
+          # macOS 14: exclude LLVM 11-15
           - os: 'macos-14'
             llvm: '11'
           - os: 'macos-14'
@@ -46,8 +46,6 @@ jobs:
             llvm: '14'
           - os: 'macos-14'
             llvm: '15'
-          - os: 'macos-14'
-            llvm: '17'
 
           # Windows: exclude LLVM 12-18
           - os: 'windows-2022'

--- a/travis.sh
+++ b/travis.sh
@@ -180,7 +180,7 @@ fi
 
 # Only deploy builds with LLVM 13 (macOS) and 11 (Windows).
 if [[ (( $(uname) == Darwin && $LLVM_VERSION = 18 ) || ( $(uname) == MINGW* && $LLVM_VERSION = 11 && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
-  RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-`uname -m`-`git rev-parse --short HEAD`
+  RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-${arch}-`git rev-parse --short HEAD`
   mv install $RELEASE_NAME
   if [[ $(uname) = MINGW* ]]; then
     7z a -t7z $RELEASE_NAME.7z $RELEASE_NAME

--- a/travis.sh
+++ b/travis.sh
@@ -33,54 +33,55 @@ if [[ $(uname) = Linux ]]; then
   exit 1
 
 elif [[ $(uname) = Darwin ]]; then
+  arch=$(uname -m)
   if [[ $LLVM_VERSION = 18 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-18.1.7/clang+llvm-18.1.7-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-18.1.7-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-18.1.7-x86_64-apple-darwin/bin/llvm-config llvm-config-17
-    ln -s clang+llvm-18.1.7-x86_64-apple-darwin/bin/clang clang-17
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-18.1.7-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-18.1.7/clang+llvm-18.1.7-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-18.1.7-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-18.1.7-${arch}-apple-darwin/bin/llvm-config llvm-config-17
+    ln -s clang+llvm-18.1.7-${arch}-apple-darwin/bin/clang clang-17
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-18.1.7-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 17 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-17.0.5/clang+llvm-17.0.5-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-17.0.5-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-17.0.5-x86_64-apple-darwin/bin/llvm-config llvm-config-17
-    ln -s clang+llvm-17.0.5-x86_64-apple-darwin/bin/clang clang-17
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-17.0.5-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-17.0.5/clang+llvm-17.0.5-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-17.0.5-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-17.0.5-${arch}-apple-darwin/bin/llvm-config llvm-config-17
+    ln -s clang+llvm-17.0.5-${arch}-apple-darwin/bin/clang clang-17
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-17.0.5-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 16 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-16.0.3/clang+llvm-16.0.3-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-16.0.3-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-16.0.3-x86_64-apple-darwin/bin/llvm-config llvm-config-16
-    ln -s clang+llvm-16.0.3-x86_64-apple-darwin/bin/clang clang-16
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-16.0.3-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-16.0.3/clang+llvm-16.0.3-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-16.0.3-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-16.0.3-${arch}-apple-darwin/bin/llvm-config llvm-config-16
+    ln -s clang+llvm-16.0.3-${arch}-apple-darwin/bin/clang clang-16
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-16.0.3-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 15 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-15.0.2/clang+llvm-15.0.2-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-15.0.2-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-15.0.2-x86_64-apple-darwin/bin/llvm-config llvm-config-15
-    ln -s clang+llvm-15.0.2-x86_64-apple-darwin/bin/clang clang-15
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-15.0.2-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-15.0.2/clang+llvm-15.0.2-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-15.0.2-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-15.0.2-${arch}-apple-darwin/bin/llvm-config llvm-config-15
+    ln -s clang+llvm-15.0.2-${arch}-apple-darwin/bin/clang clang-15
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-15.0.2-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 14 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.6/clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-14.0.6-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-14.0.6-x86_64-apple-darwin/bin/llvm-config llvm-config-14
-    ln -s clang+llvm-14.0.6-x86_64-apple-darwin/bin/clang clang-14
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.6-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.6/clang+llvm-14.0.6-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-14.0.6-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-14.0.6-${arch}-apple-darwin/bin/llvm-config llvm-config-14
+    ln -s clang+llvm-14.0.6-${arch}-apple-darwin/bin/clang clang-14
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.6-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 13 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-13.0.1/clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz
-    tar xf clang+llvm-13.0.1-x86_64-apple-darwin.tar.xz
-    ln -s clang+llvm-13.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-13
-    ln -s clang+llvm-13.0.1-x86_64-apple-darwin/bin/clang clang-13
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-13.0.1-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-13.0.1/clang+llvm-13.0.1-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-13.0.1-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-13.0.1-${arch}-apple-darwin/bin/llvm-config llvm-config-13
+    ln -s clang+llvm-13.0.1-${arch}-apple-darwin/bin/clang clang-13
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-13.0.1-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 12 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-12.0.1/clang+llvm-12.0.1-x86_64-apple-darwin-macos11.tar.xz
-    tar xf clang+llvm-12.0.1-x86_64-apple-darwin-macos11.tar.xz
-    ln -s clang+llvm-12.0.1-x86_64-apple-darwin/bin/llvm-config llvm-config-12
-    ln -s clang+llvm-12.0.1-x86_64-apple-darwin/bin/clang clang-12
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-12.0.1-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-12.0.1/clang+llvm-12.0.1-${arch}-apple-darwin-macos11.tar.xz
+    tar xf clang+llvm-12.0.1-${arch}-apple-darwin-macos11.tar.xz
+    ln -s clang+llvm-12.0.1-${arch}-apple-darwin/bin/llvm-config llvm-config-12
+    ln -s clang+llvm-12.0.1-${arch}-apple-darwin/bin/clang clang-12
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-12.0.1-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 11 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-apple-darwin-macos11.tar.xz
-    tar xf clang+llvm-11.1.0-x86_64-apple-darwin-macos11.tar.xz
-    ln -s clang+llvm-11.1.0-x86_64-apple-darwin/bin/llvm-config llvm-config-11
-    ln -s clang+llvm-11.1.0-x86_64-apple-darwin/bin/clang clang-11
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-x86_64-apple-darwin
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-${arch}-apple-darwin-macos11.tar.xz
+    tar xf clang+llvm-11.1.0-${arch}-apple-darwin-macos11.tar.xz
+    ln -s clang+llvm-11.1.0-${arch}-apple-darwin/bin/llvm-config llvm-config-11
+    ln -s clang+llvm-11.1.0-${arch}-apple-darwin/bin/clang clang-11
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-${arch}-apple-darwin
   else
     echo "Don't know this LLVM version: $LLVM_VERSION"
     exit 1

--- a/travis.sh
+++ b/travis.sh
@@ -28,12 +28,12 @@ if [[ -n $DOCKER_DISTRO ]]; then
     exit 0
 fi
 
+arch=$(uname -m | sed -e s/arm64/aarch64/)
 if [[ $(uname) = Linux ]]; then
   echo "Use Docker for testing build on Linux"
   exit 1
 
 elif [[ $(uname) = Darwin ]]; then
-  arch=$(uname -m)
   if [[ $LLVM_VERSION = 18 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-18.1.7/clang+llvm-18.1.7-${arch}-apple-darwin.tar.xz
     tar xf clang+llvm-18.1.7-${arch}-apple-darwin.tar.xz
@@ -96,13 +96,13 @@ elif [[ $(uname) = Darwin ]]; then
 
 elif [[ $(uname) = MINGW* ]]; then
   if [[ $LLVM_VERSION = 14 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-x86_64-windows-msvc17.7z
-    7z x -y clang+llvm-14.0.0-x86_64-windows-msvc17.7z
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.0-x86_64-windows-msvc17
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-14.0.0/clang+llvm-14.0.0-${arch}-windows-msvc17.7z
+    7z x -y clang+llvm-14.0.0-${arch}-windows-msvc17.7z
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-14.0.0-${arch}-windows-msvc17
   elif [[ $LLVM_VERSION = 11 ]]; then
-    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-x86_64-windows-msvc17.7z
-    7z x -y clang+llvm-11.1.0-x86_64-windows-msvc17.7z
-    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-x86_64-windows-msvc17
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-11.1.0/clang+llvm-11.1.0-${arch}-windows-msvc17.7z
+    7z x -y clang+llvm-11.1.0-${arch}-windows-msvc17.7z
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-11.1.0-${arch}-windows-msvc17
   fi
 
   if [[ $USE_CUDA -eq 1 ]]; then


### PR DESCRIPTION
This should also enable binaries to be included in the next release.

Note that runs under `macos-14` run on M1 hardware, whereas previous macOS versions run on x86 hardware. This is a GitHub-specific decision and not specific to the way that macOS works (macOS 14 still runs fine on x86).