### PR TITLE
Add AVX512 support

### DIFF
--- a/tests/avx512.t
+++ b/tests/avx512.t
@@ -1,0 +1,8 @@
+local vec = vector(int8, 64)
+terra compute(x: vec, y: vec)
+    -- vec has a size of 8 * 64 = 512 bits so this operation should compile
+    -- to a single AVX512 instruction
+    return x + y
+end
+compute:compile()
+compute:disas()


### PR DESCRIPTION
Many modern CPUs support AVX512 with 512 bit wide vector instructions. Currently, terra only enables AVX extensions (256 bit) for its `vector` type. This PR enables basic AVX512 features if the host CPU supports it.

### Advantages

This potentially speeds up computations with the `vector` type by factor of 2 as twice as many instructions can be handled at the same time.

### Disadvantages

None as the old code path (AVX only) is used if the CPU does not support all required AVX512 instruction sets.