### PR TITLE
Bump CI to macOS 13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        # Note: macOS 12 runs on x86 hardware, and 14 runs on M1 hardware
-        os: ['macos-12', 'macos-14', 'windows-2022']
+        # Note: macOS 13 runs on x86 hardware, and 14 runs on M1 hardware
+        os: ['macos-13', 'macos-14', 'windows-2022']
         llvm: ['11', '12', '13', '14', '15', '16', '17', '18']
         cuda: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
           # macOS: exclude cuda
-          - os: 'macos-12'
+          - os: 'macos-13'
             cuda: '1'
           - os: 'macos-14'
             cuda: '1'


### PR DESCRIPTION
According to a recent email announcement:

> The macOS 12 runner image will be removed by December 3rd, 2024.

So we're bumping up to macOS 13.

Not sure what we'll do when they remove the last x86 OS version, but we'll cross that bridge when we get there.