### PR TITLE
Fix FreeBSD version for CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,7 @@ freebsd_task:
   name: FreeBSD
   freebsd_instance:
     matrix:
-      image_family: freebsd-14-0
+      image_family: freebsd-14-2
   env:
     matrix:
       LLVM_VERSION: 11


### PR DESCRIPTION
Apparently 14.0 isn't available anymore, so bumping up to 14.2.

https://cirrus-ci.org/guide/FreeBSD/#list-of-available-image-families