### PR TITLE
Disable emulated multiarch and switch to native ARM runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,7 +271,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04" "" 11.1.0 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04" "" 11.1.0 luajit prebuilt 2
       - uses: actions/upload-artifact@v4
         with:
           name: docker-ubuntu-20.04-arm64-llvm-11

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,10 +259,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04 24.04" "" 18.1.7 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04" "" 18.1.7 luajit prebuilt 2
       - uses: actions/upload-artifact@v4
         with:
-          name: docker-ubuntu-18.04-x86_64-llvm-18
+          name: docker-ubuntu-20.04-x86_64-llvm-18
           path: |
             terra-*.tar.xz
             terra-*.7z
@@ -271,10 +271,10 @@ jobs:
     runs-on: ubuntu-24.04-arm
     steps:
       - uses: actions/checkout@v4
-      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04 24.04" "" 11.1.0 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04" "" 11.1.0 luajit prebuilt 2
       - uses: actions/upload-artifact@v4
         with:
-          name: docker-ubuntu-18.04-arm64-llvm-11
+          name: docker-ubuntu-20.04-arm64-llvm-11
           path: |
             terra-*.tar.xz
             terra-*.7z

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -259,10 +259,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04" "" 18.1.7 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04 24.04" "" 18.1.7 luajit prebuilt 2
       - uses: actions/upload-artifact@v4
         with:
-          name: docker-ubuntu-20.04-x86_64-llvm-18
+          name: docker-ubuntu-18.04-x86_64-llvm-18
           path: |
             terra-*.tar.xz
             terra-*.7z

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -222,38 +222,38 @@ jobs:
           DOCKER_CUDA: ${{ matrix.cuda }}
           DOCKER_VARIANT: ${{ matrix.variant }}
           DOCKER_TEST: ${{ matrix.test }}
-  multiarch:
-    name: Multiarch (${{ matrix.distro }}, ${{ matrix.arch }}, llvm-${{ matrix.llvm }}, cuda=${{ matrix.cuda }}, ${{ matrix.variant }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        distro: [] # ['ubuntu-18.04'] # DISABLED
-        arch: ['arm64', 'ppc64le']
-        llvm: ['11.1.0', '13.0.0']
-        variant: ['prebuilt']
-        cuda: ['0']
-        test: ['0']
-        exclude:
-          - arch: 'arm64'
-            llvm: '13.0.0'
-          - arch: 'ppc64le'
-            llvm: '11.1.0'
-    steps:
-      - uses: actions/checkout@v4
-      - run: ./travis.sh
-        env:
-          DOCKER_DISTRO: ${{ matrix.distro }}
-          DOCKER_ARCH: ${{ matrix.arch }}
-          DOCKER_LLVM: ${{ matrix.llvm }}
-          DOCKER_CUDA: ${{ matrix.cuda }}
-          DOCKER_VARIANT: ${{ matrix.variant }}
-          DOCKER_TEST: ${{ matrix.test }}
-      - uses: actions/upload-artifact@v4
-        with:
-          name: docker-${{ matrix.distro }}-${{ matrix.arch }}-llvm-${{ matrix.llvm }}
-          path: |
-            terra-*.tar.xz
-            terra-*.7z
+  # multiarch:
+  #   name: Multiarch (${{ matrix.distro }}, ${{ matrix.arch }}, llvm-${{ matrix.llvm }}, cuda=${{ matrix.cuda }}, ${{ matrix.variant }})
+  #   runs-on: ubuntu-latest
+  #   strategy:
+  #     matrix:
+  #       distro: ['ubuntu-18.04']
+  #       arch: ['arm64', 'ppc64le']
+  #       llvm: ['11.1.0', '13.0.0']
+  #       variant: ['prebuilt']
+  #       cuda: ['0']
+  #       test: ['0']
+  #       exclude:
+  #         - arch: 'arm64'
+  #           llvm: '13.0.0'
+  #         - arch: 'ppc64le'
+  #           llvm: '11.1.0'
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     - run: ./travis.sh
+  #       env:
+  #         DOCKER_DISTRO: ${{ matrix.distro }}
+  #         DOCKER_ARCH: ${{ matrix.arch }}
+  #         DOCKER_LLVM: ${{ matrix.llvm }}
+  #         DOCKER_CUDA: ${{ matrix.cuda }}
+  #         DOCKER_VARIANT: ${{ matrix.variant }}
+  #         DOCKER_TEST: ${{ matrix.test }}
+  #     - uses: actions/upload-artifact@v4
+  #       with:
+  #         name: docker-${{ matrix.distro }}-${{ matrix.arch }}-llvm-${{ matrix.llvm }}
+  #         path: |
+  #           terra-*.tar.xz
+  #           terra-*.7z
   compat:
     name: Compatibility Test
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -227,7 +227,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        distro: ['ubuntu-18.04']
+        distro: [] # ['ubuntu-18.04'] # DISABLED
         arch: ['arm64', 'ppc64le']
         llvm: ['11.1.0', '13.0.0']
         variant: ['prebuilt']
@@ -263,6 +263,18 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: docker-ubuntu-18.04-x86_64-llvm-18
+          path: |
+            terra-*.tar.xz
+            terra-*.7z
+  compat_arm64:
+    name: Compatibility Test (ARM64)
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - run: ./docker/compatibility_test.sh ubuntu 18.04 "18.04 20.04 22.04 24.04" "" 11.1.0 luajit prebuilt 2
+      - uses: actions/upload-artifact@v4
+        with:
+          name: docker-ubuntu-18.04-arm64-llvm-11
           path: |
             terra-*.tar.xz
             terra-*.7z

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -5,11 +5,13 @@ set -x
 
 sudo_command="$1"
 
+arch=$(uname -m | sed -e s/ppc64le/powerpc64le/)
+
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common
-wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/cuda-ubuntu1804.pin
+wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/cuda-ubuntu1804.pin
 $sudo_command mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/3bf863cc.pub
-$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/x86_64/ /"
+$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/3bf863cc.pub
+$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/ /"
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq cuda-compiler-11.6

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -21,9 +21,9 @@ $sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/com
 $sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$release/$arch/ /"
 $sudo_command apt-get update -qq
 if [[ $release = 1804 ]]; then
-    $sudo_command apt-get install -qq cuda-compiler-12.2
-elif [[ $release = 2004 ]]; then
     $sudo_command apt-get install -qq cuda-compiler-12.1
+elif [[ $release = 2004 ]]; then
+    $sudo_command apt-get install -qq cuda-compiler-12.2
 else
     echo "Don't know how to install CUDA for this distro"
     lsb_release -a

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -23,9 +23,9 @@ $sudo_command apt-get update -qq
 if [[ $release = 1804 ]]; then
     $sudo_command apt-get install -qq cuda-compiler-12.1
 elif [[ $release = 2004 ]]; then
-    $sudo_command apt-get install -qq cuda-compiler-12.2
+    $sudo_command apt-get install -qq cuda-compiler-12.5
 else
     echo "Don't know how to install CUDA for this distro"
-    lsb_release -a
+    cat /etc/lsb_release
     exit 1
 fi

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -5,7 +5,7 @@ set -x
 
 sudo_command="$1"
 
-arch=$(uname -m | sed -e s/ppc64le/powerpc64le/)
+arch=$(uname -m | sed -e s/aarch64/arm64/)
 
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -5,8 +5,7 @@ set -x
 
 sudo_command="$1"
 
-release=$(. /etc/lsb-release; echo "${DISTRIB_RELEASE//
-.}")
+release=$(. /etc/lsb-release; echo "${DISTRIB_RELEASE//.}")
 
 arch=$(uname -m | sed -e s/aarch64/arm64/)
 

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -20,4 +20,12 @@ $sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/com
 
 $sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$release/$arch/ /"
 $sudo_command apt-get update -qq
-$sudo_command apt-get install -qq cuda-compiler-12.2
+if [[ $release = 1804 ]]; then
+    $sudo_command apt-get install -qq cuda-compiler-12.2
+elif [[ $release = 2004 ]]; then
+    $sudo_command apt-get install -qq cuda-compiler-12.1
+else
+    echo "Don't know how to install CUDA for this distro"
+    lsb_release -a
+    exit 1
+fi

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -5,17 +5,20 @@ set -x
 
 sudo_command="$1"
 
+release=$(. /etc/lsb-release; echo "${DISTRIB_RELEASE//
+.}")
+
 arch=$(uname -m | sed -e s/aarch64/arm64/)
 
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common
-wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/$arch/cuda-ubuntu2004.pin
-$sudo_command mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$release/$arch/cuda-ubuntu$release.pin
+$sudo_command mv cuda-ubuntu$release.pin /etc/apt/preferences.d/cuda-repository-pin-600
 
 # Just fetch all the keys, since they seem to reuse these between distributions.
 $sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
 $sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
 
-$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/$arch/ /"
+$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu$release/$arch/ /"
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq cuda-compiler-12.2

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -11,7 +11,16 @@ $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common
 wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/cuda-ubuntu1804.pin
 $sudo_command mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
-$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/3bf863cc.pub
+
+if [[ $arch = x86_64 ]]; then
+    key=3bf863cc.pub
+elif [[ $arch = arm64 ]]; then
+    key=7fa2af80.pub
+else
+    echo "Unrecognized arch $arch"
+    exit 1
+fi
+$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/$key
 $sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/ /"
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq cuda-compiler-11.6

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -9,18 +9,13 @@ arch=$(uname -m | sed -e s/aarch64/arm64/)
 
 $sudo_command apt-get update -qq
 $sudo_command apt-get install -qq software-properties-common
-wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/cuda-ubuntu1804.pin
-$sudo_command mv cuda-ubuntu1804.pin /etc/apt/preferences.d/cuda-repository-pin-600
+wget -nv https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/$arch/cuda-ubuntu2004.pin
+$sudo_command mv cuda-ubuntu2004.pin /etc/apt/preferences.d/cuda-repository-pin-600
 
-if [[ $arch = x86_64 ]]; then
-    key=3bf863cc.pub
-elif [[ $arch = arm64 ]]; then
-    key=7fa2af80.pub
-else
-    echo "Unrecognized arch $arch"
-    exit 1
-fi
-$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/$key
-$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu1804/$arch/ /"
+# Just fetch all the keys, since they seem to reuse these between distributions.
+$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/3bf863cc.pub
+$sudo_command apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/7fa2af80.pub
+
+$sudo_command add-apt-repository "deb https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/$arch/ /"
 $sudo_command apt-get update -qq
-$sudo_command apt-get install -qq cuda-compiler-11.6
+$sudo_command apt-get install -qq cuda-compiler-12.2

--- a/docker/install_cuda.sh
+++ b/docker/install_cuda.sh
@@ -23,7 +23,7 @@ $sudo_command apt-get update -qq
 if [[ $release = 1804 ]]; then
     $sudo_command apt-get install -qq cuda-compiler-12.1
 elif [[ $release = 2004 ]]; then
-    $sudo_command apt-get install -qq cuda-compiler-12.5
+    $sudo_command apt-get install -qq cuda-compiler-12.2
 else
     echo "Don't know how to install CUDA for this distro"
     cat /etc/lsb_release


### PR DESCRIPTION
Initial exploration of alternatives in #685 has been unsuccessful, so switch ARM64 jobs over to native hardware and disable emulated multiarch jobs for now. Perhaps we'll find a solution at some point, but I suspect a QEMU bug is causing crashes in GCC.

 * Enables compatibility test for ARM64:
   * Ubuntu 20.04 base build
   * CUDA 12.2
   * Tested up to Ubuntu 22.04
   * Ubuntu 24.04 fails to parse NEON headers, probably gated on LLVM version
 * x86 build for Ubuntu 20.04 requires a rebuild of LLVM binaries, so defer that for now
   * But do upgrade CUDA to 12.1 so we're on something less ancient