### PR TITLE
Track start offset and whitespace start offset for lexer

### DIFF
--- a/src/llex.h
+++ b/src/llex.h
@@ -153,6 +153,8 @@ typedef struct LexState {
     int linenumber; /* input line counter */
     int lastline;   /* line of last token `consumed' */
     int currentoffset;
+    int start_offset;
+    int ws_start_offset;
     Token t;              /* current token */
     Token lookahead;      /* look ahead token */
     struct FuncState *fs; /* current function (parser) */

--- a/src/lparser.cpp
+++ b/src/lparser.cpp
@@ -140,6 +140,10 @@ static Position getposition(LexState *ls) {
 static void table_setposition(LexState *ls, int t, Position p) {
     lua_pushinteger(ls->L, p.linenumber);
     lua_setfield(ls->L, t, "linenumber");
+    lua_pushinteger(ls->L, ls->start_offset);
+    lua_setfield(ls->L, t, "start_offset");
+    lua_pushinteger(ls->L, ls->ws_start_offset);
+    lua_setfield(ls->L, t, "ws_start_offset");
     lua_pushinteger(ls->L, p.offset);
     lua_setfield(ls->L, t, "offset");
     lua_pushstring(ls->L, getstr(ls->source));


### PR DESCRIPTION
This makes it possible to get more accurate information for extracting out
tokens from the source

I'm using this to do `dbg` and `expect` style testing where I can modify
source in place with snapshot tests