### PR TITLE
Add support for LLVM 20, try 2 (and LLVM 21)

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,6 +14,7 @@ freebsd_task:
       LLVM_VERSION: 18
       LLVM_VERSION: 19
       LLVM_VERSION: 20
+      LLVM_VERSION: 21
   install_script: pkg install -y bash coreutils cmake gmake llvm$LLVM_VERSION
   script: |
     export CC=cc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -13,6 +13,7 @@ freebsd_task:
       LLVM_VERSION: 17
       LLVM_VERSION: 18
       LLVM_VERSION: 19
+      LLVM_VERSION: 20
   install_script: pkg install -y bash coreutils cmake gmake llvm$LLVM_VERSION
   script: |
     export CC=cc

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,12 +56,6 @@ jobs:
           - os: 'macos-15'
             llvm: '15'
 
-          # Windows: exclude LLVM 20-21
-          - os: 'windows-2022'
-            llvm: '20'
-          - os: 'windows-2022'
-            llvm: '21'
-
           # CUDA: only LLVM 11
           - llvm: '12'
             cuda: '1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-15-intel', 'macos-15', 'windows-2022']
-        llvm: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20']
+        llvm: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21']
         cuda: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
@@ -56,6 +56,12 @@ jobs:
           - os: 'macos-15'
             llvm: '15'
 
+          # Windows: exclude LLVM 20-21
+          - os: 'windows-2022'
+            llvm: '20'
+          - os: 'windows-2022'
+            llvm: '21'
+
           # CUDA: only LLVM 11
           - llvm: '12'
             cuda: '1'
@@ -74,6 +80,8 @@ jobs:
           - llvm: '19'
             cuda: '1'
           - llvm: '20'
+            cuda: '1'
+          - llvm: '21'
             cuda: '1'
 
           # Moonjit: only LLVM 15
@@ -94,6 +102,8 @@ jobs:
           - llvm: '19'
             lua: 'moonjit'
           - llvm: '20'
+            lua: 'moonjit'
+          - llvm: '21'
             lua: 'moonjit'
     steps:
       - uses: actions/checkout@v4
@@ -119,7 +129,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-20.04']
-        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.7', '16.0.6', '17.0.6', '18.1.8', '19.1.7', '20.1.8']
+        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.7', '16.0.6', '17.0.6', '18.1.8', '19.1.7', '20.1.8', '21.1.8']
         lua: ['luajit', 'moonjit']
         cuda: ['0', '1']
         test: ['1']
@@ -143,6 +153,8 @@ jobs:
             cuda: '1'
           - llvm: '20.1.8'
             cuda: '1'
+          - llvm: '21.1.8'
+            cuda: '1'
 
           # Moonjit with LLVM 14 only:
           - llvm: '11'
@@ -162,6 +174,8 @@ jobs:
           - llvm: '19.1.7'
             lua: 'moonjit'
           - llvm: '20.1.8'
+            lua: 'moonjit'
+          - llvm: '21.1.8'
             lua: 'moonjit'
 
         include:
@@ -268,10 +282,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04 25.04" "" 20.1.8 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04 25.04" "" 21.1.8 luajit prebuilt 2
       - uses: actions/upload-artifact@v4
         with:
-          name: docker-ubuntu-20.04-x86_64-llvm-20
+          name: docker-ubuntu-20.04-x86_64-llvm-21
           path: |
             terra-*.tar.xz
             terra-*.7z

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: ['macos-15-intel', 'macos-15', 'windows-2022']
-        llvm: ['11', '12', '13', '14', '15', '16', '17', '18', '19']
+        llvm: ['11', '12', '13', '14', '15', '16', '17', '18', '19', '20']
         cuda: ['0', '1']
         lua: ['luajit', 'moonjit']
         exclude:
@@ -73,6 +73,8 @@ jobs:
             cuda: '1'
           - llvm: '19'
             cuda: '1'
+          - llvm: '20'
+            cuda: '1'
 
           # Moonjit: only LLVM 15
           - llvm: '11'
@@ -90,6 +92,8 @@ jobs:
           - llvm: '18'
             lua: 'moonjit'
           - llvm: '19'
+            lua: 'moonjit'
+          - llvm: '20'
             lua: 'moonjit'
     steps:
       - uses: actions/checkout@v4
@@ -115,7 +119,7 @@ jobs:
     strategy:
       matrix:
         distro: ['ubuntu-20.04']
-        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.7', '16.0.6', '17.0.6', '18.1.8', '19.1.7']
+        llvm: ['11', '12.0.1', '13.0.1', '14.0.6', '15.0.7', '16.0.6', '17.0.6', '18.1.8', '19.1.7', '20.1.8']
         lua: ['luajit', 'moonjit']
         cuda: ['0', '1']
         test: ['1']
@@ -137,6 +141,8 @@ jobs:
             cuda: '1'
           - llvm: '19.1.7'
             cuda: '1'
+          - llvm: '20.1.8'
+            cuda: '1'
 
           # Moonjit with LLVM 14 only:
           - llvm: '11'
@@ -154,6 +160,8 @@ jobs:
           - llvm: '18.1.8'
             lua: 'moonjit'
           - llvm: '19.1.7'
+            lua: 'moonjit'
+          - llvm: '20.1.8'
             lua: 'moonjit'
 
         include:
@@ -260,10 +268,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04 25.04" "" 19.1.7 luajit prebuilt 2
+      - run: ./docker/compatibility_test.sh ubuntu 20.04 "20.04 22.04 24.04 25.04" "" 20.1.8 luajit prebuilt 2
       - uses: actions/upload-artifact@v4
         with:
-          name: docker-ubuntu-20.04-x86_64-llvm-19
+          name: docker-ubuntu-20.04-x86_64-llvm-20
           path: |
             terra-*.tar.xz
             terra-*.7z

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,10 @@ jobs:
           - os: 'macos-15'
             llvm: '15'
 
+          # Windows: LLVM 21 is broken
+          - os: 'windows-2022'
+            llvm: '21'
+
           # CUDA: only LLVM 11
           - llvm: '12'
             cuda: '1'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      LLVM_VERSION: 11.1.0
-      LLVM_VERSION_SHORT: 110
+      LLVM_VERSION: 20.1.8
+      LLVM_VERSION_SHORT: 200
       VS_MAJOR_VERSION: 17
       USE_CUDA: 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      LLVM_VERSION: 19.1.7
-      LLVM_VERSION_SHORT: 190
+      LLVM_VERSION: 21.1.8
+      LLVM_VERSION_SHORT: 210
       VS_MAJOR_VERSION: 17
       USE_CUDA: 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      LLVM_VERSION: 20.1.8
-      LLVM_VERSION_SHORT: 200
+      LLVM_VERSION: 21.1.8
+      LLVM_VERSION_SHORT: 210
       VS_MAJOR_VERSION: 17
       USE_CUDA: 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      LLVM_VERSION: 21.1.8
-      LLVM_VERSION_SHORT: 210
+      LLVM_VERSION: 19.1.7
+      LLVM_VERSION_SHORT: 190
       VS_MAJOR_VERSION: 17
       USE_CUDA: 1
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,8 +1,8 @@
 environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
-      LLVM_VERSION: 21.1.8
-      LLVM_VERSION_SHORT: 210
+      LLVM_VERSION: 20.1.8
+      LLVM_VERSION_SHORT: 200
       VS_MAJOR_VERSION: 17
       USE_CUDA: 1
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -141,7 +141,7 @@ pkg install -y cmake gmake llvm18
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **20** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
+The current recommended version of LLVM is **21** for most platforms, except Windows where LLVM 19 is the highest supported version, and Linux (ARM) where LLVM 11 is required. The following versions are also supported:
 
 | Version |         Linux |         macOS |       FreeBSD |       Windows |   NVIDIA/CUDA | AMD/HIP \*     | Intel/SPIRV \*\* | Notes |
 | ------- | ------------- | ------------- | ------------- | ------------- | ------------- | -------------- | ---------------- | ----- |
@@ -154,9 +154,10 @@ The current recommended version of LLVM is **20** for most platforms, except Lin
 |      17 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |    :green_heart: | |
 |      18 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 |      19 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
-|      20 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
+|      20 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
+|      21 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
 
-\* AMD GPU support is currently experimental. LLVM 20 is **strongly** recommended.
+\* AMD GPU support is currently experimental. LLVM 21 is **strongly** recommended.
 
 \*\* Intel GPU (SPIR-V) support is currently experimental.
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -141,7 +141,7 @@ pkg install -y cmake gmake llvm18
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **21** for most platforms, except Windows where LLVM 19 is the highest supported version, and Linux (ARM) where LLVM 11 is required. The following versions are also supported:
+The current recommended version of LLVM is **21** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
 
 | Version |         Linux |         macOS |       FreeBSD |       Windows |   NVIDIA/CUDA | AMD/HIP \*     | Intel/SPIRV \*\* | Notes |
 | ------- | ------------- | ------------- | ------------- | ------------- | ------------- | -------------- | ---------------- | ----- |
@@ -154,8 +154,8 @@ The current recommended version of LLVM is **21** for most platforms, except Win
 |      17 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |    :green_heart: | |
 |      18 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 |      19 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
-|      20 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
-|      21 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
+|      20 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
+|      21 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 
 \* AMD GPU support is currently experimental. LLVM 21 is **strongly** recommended.
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -141,7 +141,7 @@ pkg install -y cmake gmake llvm18
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **19** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
+The current recommended version of LLVM is **20** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
 
 | Version |         Linux |         macOS |       FreeBSD |       Windows |   NVIDIA/CUDA | AMD/HIP \*     | Intel/SPIRV \*\* | Notes |
 | ------- | ------------- | ------------- | ------------- | ------------- | ------------- | -------------- | ---------------- | ----- |
@@ -154,8 +154,9 @@ The current recommended version of LLVM is **19** for most platforms, except Lin
 |      17 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |    :green_heart: | |
 |      18 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 |      19 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
+|      20 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 
-\* AMD GPU support is currently experimental. LLVM 19 is **strongly** recommended.
+\* AMD GPU support is currently experimental. LLVM 20 is **strongly** recommended.
 
 \*\* Intel GPU (SPIR-V) support is currently experimental.
 

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -141,7 +141,7 @@ pkg install -y cmake gmake llvm18
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **21** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
+The current recommended version of LLVM is **20** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
 
 | Version |         Linux |         macOS |       FreeBSD |       Windows |   NVIDIA/CUDA | AMD/HIP \*     | Intel/SPIRV \*\* | Notes |
 | ------- | ------------- | ------------- | ------------- | ------------- | ------------- | -------------- | ---------------- | ----- |
@@ -155,9 +155,9 @@ The current recommended version of LLVM is **21** for most platforms, except Lin
 |      18 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 |      19 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
 |      20 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
-|      21 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
+|      21 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
 
-\* AMD GPU support is currently experimental. LLVM 21 is **strongly** recommended.
+\* AMD GPU support is currently experimental. LLVM 20 is **strongly** recommended.
 
 \*\* Intel GPU (SPIR-V) support is currently experimental.
 

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -74,11 +74,13 @@
 #include "llvmheaders_190.h"
 #elif LLVM_VERSION < 210
 #include "llvmheaders_200.h"
+#elif LLVM_VERSION < 220
+#include "llvmheaders_210.h"
 #else
 #error "unsupported LLVM version"
 // for OSX code completion
-#define LLVM_VERSION 200
-#include "llvmheaders_200.h"
+#define LLVM_VERSION 210
+#include "llvmheaders_210.h"
 #endif
 
 #define UNIQUEIFY(T, x) (std::unique_ptr<T>(x))

--- a/src/llvmheaders.h
+++ b/src/llvmheaders.h
@@ -72,11 +72,13 @@
 #include "llvmheaders_180.h"
 #elif LLVM_VERSION < 200
 #include "llvmheaders_190.h"
+#elif LLVM_VERSION < 210
+#include "llvmheaders_200.h"
 #else
 #error "unsupported LLVM version"
 // for OSX code completion
-#define LLVM_VERSION 180
-#include "llvmheaders_180.h"
+#define LLVM_VERSION 200
+#include "llvmheaders_200.h"
 #endif
 
 #define UNIQUEIFY(T, x) (std::unique_ptr<T>(x))

--- a/src/llvmheaders_200.h
+++ b/src/llvmheaders_200.h
@@ -1,0 +1,34 @@
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Support/Error.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::OF_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::OF_None

--- a/src/llvmheaders_210.h
+++ b/src/llvmheaders_210.h
@@ -1,0 +1,34 @@
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/LLVMContext.h"
+#include "llvm/IR/Module.h"
+#include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/IntrinsicInst.h"
+#include "llvm/IR/InlineAsm.h"
+#include "llvm/Analysis/CallGraphSCCPass.h"
+#include "llvm/Analysis/CallGraph.h"
+#include "llvm/IR/DIBuilder.h"
+#include "llvm/IR/DebugInfo.h"
+#include "llvm/IR/Mangler.h"
+//#include "llvm/ExecutionEngine/ObjectImage.h"
+#include "llvm/IR/Verifier.h"
+#include "llvm/Linker/Linker.h"
+#include "llvm/IR/CFG.h"
+#include "llvm/IR/InstVisitor.h"
+#include "llvm/CodeGen/TargetSubtargetInfo.h"
+
+#include "llvm/Support/VirtualFileSystem.h"
+#include "clang/Rewrite/Core/Rewriter.h"
+#include "clang/Rewrite/Frontend/Rewriters.h"
+#include "llvm/IR/DiagnosticPrinter.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/Object/SymbolSize.h"
+
+#include "llvm/Bitcode/BitcodeReader.h"
+#include "llvm/Support/Error.h"
+
+#define LLVM_PATH_TYPE std::string
+#define RAW_FD_OSTREAM_NONE sys::fs::OF_None
+#define RAW_FD_OSTREAM_BINARY sys::fs::OF_None

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -3368,7 +3368,7 @@ struct FunctionEmitter {
         ValueToValueMapTy VMap;
         DebugInfoFinder DIFinder;
         BasicBlock *NewBB =
-#if LLVM_VERSION < 20
+#if LLVM_VERSION < 200
                 CloneBasicBlock(BB, VMap, "defer", fstate->func, nullptr, &DIFinder);
 #else
                 // TODO: Check if DIFinder needs to be used in a different function.

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -3368,7 +3368,12 @@ struct FunctionEmitter {
         ValueToValueMapTy VMap;
         DebugInfoFinder DIFinder;
         BasicBlock *NewBB =
+#if LLVM_VERSION < 20
                 CloneBasicBlock(BB, VMap, "defer", fstate->func, nullptr, &DIFinder);
+#else
+                // TODO: Check if DIFinder needs to be used in a different function.
+                CloneBasicBlock(BB, VMap, "defer", fstate->func, nullptr);
+#endif
         VMap[BB] = NewBB;
 
         BasicBlock::iterator oldII = BB->begin();

--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -828,13 +828,21 @@ static void initializeclang(terra_State *T, llvm::MemoryBuffer *membuffer,
                             llvm::IntrusiveRefCntPtr<llvm::vfs::FileSystem> FS) {
     // CompilerInstance will hold the instance of the Clang compiler for us,
     // managing the various objects needed to run the compiler.
+#if LLVM_VERSION < 200
     TheCompInst->createDiagnostics();
+#else
+    TheCompInst->createDiagnostics(*FS);
+#endif
 
     CompilerInvocation::CreateFromArgs(TheCompInst->getInvocation(), args,
                                        TheCompInst->getDiagnostics());
     // need to recreate the diagnostics engine so that it actually listens to warning
     // flags like -Wno-deprecated this cannot go before CreateFromArgs
+#if LLVM_VERSION < 200
     TheCompInst->createDiagnostics();
+#else
+    TheCompInst->createDiagnostics(*FS);
+#endif
     std::shared_ptr<TargetOptions> to(new TargetOptions(TheCompInst->getTargetOpts()));
 
     TargetInfo *TI = TargetInfo::CreateTargetInfo(TheCompInst->getDiagnostics(), to);

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -37,6 +37,10 @@
 #include "llvm/Transforms/Vectorize/VectorCombine.h"
 #endif
 
+#if LLVM_VERSION >= 200
+#include "llvm/Transforms/Utils/ExtraPassManager.h"
+#endif
+
 #ifndef _WIN32
 #include <sys/wait.h>
 #endif
@@ -117,7 +121,11 @@ void addVectorPasses(PipelineTuningOptions PTO, OptimizationLevel Level,
     FPM.addPass(InstCombinePass());
 
     if (Level.getSpeedupLevel() > 1 && ExtraVectorizerPasses) {
+#if LLVM_VERSION < 200
         ExtraVectorPassManager ExtraPasses;
+#else
+        ExtraFunctionPassManager<ShouldRunExtraVectorPasses> ExtraPasses;
+#endif
         // At higher optimization levels, try to clean up any runtime overlap and
         // alignment checks inserted by the vectorizer. We want to track correlated
         // runtime checks for two inner loops in the same outer loop, fold any

--- a/travis.sh
+++ b/travis.sh
@@ -34,7 +34,13 @@ if [[ $(uname) = Linux ]]; then
   exit 1
 
 elif [[ $(uname) = Darwin ]]; then
-  if [[ $LLVM_VERSION = 19 ]]; then
+  if [[ $LLVM_VERSION = 20 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-20.1.8/clang+llvm-20.1.8-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-20.1.8-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/llvm-config llvm-config-19
+    ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/clang clang-19
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-20.1.8-${arch}-apple-darwin
+  elif [[ $LLVM_VERSION = 19 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-19.1.7/clang+llvm-19.1.7-${arch}-apple-darwin.tar.xz
     tar xf clang+llvm-19.1.7-${arch}-apple-darwin.tar.xz
     ln -s clang+llvm-19.1.7-${arch}-apple-darwin/bin/llvm-config llvm-config-19
@@ -101,7 +107,11 @@ elif [[ $(uname) = Darwin ]]; then
   export PATH=$PWD:$PATH
 
 elif [[ $(uname) = MINGW* ]]; then
-  if [[ $LLVM_VERSION = 19 ]]; then
+  if [[ $LLVM_VERSION = 20 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-20.1.8/clang+llvm-20.1.8-${arch}-windows-msvc17.7z
+    7z x -y clang+llvm-20.1.8-${arch}-windows-msvc17.7z
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-20.1.8-${arch}-windows-msvc17
+  elif [[ $LLVM_VERSION = 19 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-19.1.7/clang+llvm-19.1.7-${arch}-windows-msvc17.7z
     7z x -y clang+llvm-19.1.7-${arch}-windows-msvc17.7z
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-19.1.7-${arch}-windows-msvc17
@@ -212,8 +222,8 @@ if [[ $(uname) != Darwin ]]; then
     popd
 fi
 
-# Only deploy builds with LLVM 13 (macOS) and 11 (Windows).
-if [[ (( $(uname) == Darwin && $LLVM_VERSION = 18 ) || ( $(uname) == MINGW* && $LLVM_VERSION = 11 && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
+# Only deploy builds with LLVM 20.
+if [[ $LLVM_VERSION = 20 && ( ! ( $(uname) == MINGW* ) && $USE_CUDA -eq 1 ) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
   RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-${arch}-`git rev-parse --short HEAD`
   mv install $RELEASE_NAME
   if [[ $(uname) = MINGW* ]]; then

--- a/travis.sh
+++ b/travis.sh
@@ -34,7 +34,13 @@ if [[ $(uname) = Linux ]]; then
   exit 1
 
 elif [[ $(uname) = Darwin ]]; then
-  if [[ $LLVM_VERSION = 20 ]]; then
+  if [[ $LLVM_VERSION = 21 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-21.1.8/clang+llvm-21.1.8-${arch}-apple-darwin.tar.xz
+    tar xf clang+llvm-21.1.8-${arch}-apple-darwin.tar.xz
+    ln -s clang+llvm-21.1.8-${arch}-apple-darwin/bin/llvm-config llvm-config-21
+    ln -s clang+llvm-21.1.8-${arch}-apple-darwin/bin/clang clang-21
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-21.1.8-${arch}-apple-darwin
+  elif [[ $LLVM_VERSION = 20 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-20.1.8/clang+llvm-20.1.8-${arch}-apple-darwin.tar.xz
     tar xf clang+llvm-20.1.8-${arch}-apple-darwin.tar.xz
     ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/llvm-config llvm-config-20
@@ -107,7 +113,11 @@ elif [[ $(uname) = Darwin ]]; then
   export PATH=$PWD:$PATH
 
 elif [[ $(uname) = MINGW* ]]; then
-  if [[ $LLVM_VERSION = 20 ]]; then
+  if [[ $LLVM_VERSION = 21 ]]; then
+    curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-21.1.8/clang+llvm-21.1.8-${arch}-windows-msvc17.7z
+    7z x -y clang+llvm-21.1.8-${arch}-windows-msvc17.7z
+    export CMAKE_PREFIX_PATH=$PWD/clang+llvm-21.1.8-${arch}-windows-msvc17
+  elif [[ $LLVM_VERSION = 20 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-20.1.8/clang+llvm-20.1.8-${arch}-windows-msvc17.7z
     7z x -y clang+llvm-20.1.8-${arch}-windows-msvc17.7z
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-20.1.8-${arch}-windows-msvc17
@@ -222,8 +232,8 @@ if [[ $(uname) != Darwin ]]; then
     popd
 fi
 
-# Only deploy builds with LLVM 20.
-if [[ $LLVM_VERSION = 20 && ( ! ( $(uname) == MINGW* ) && $USE_CUDA -eq 1 ) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
+# Only deploy builds with LLVM 21.
+if [[ $LLVM_VERSION = 21 && ( ! ( $(uname) == MINGW* ) && $USE_CUDA -eq 1 ) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
   RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-${arch}-`git rev-parse --short HEAD`
   mv install $RELEASE_NAME
   if [[ $(uname) = MINGW* ]]; then

--- a/travis.sh
+++ b/travis.sh
@@ -37,8 +37,8 @@ elif [[ $(uname) = Darwin ]]; then
   if [[ $LLVM_VERSION = 20 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-20.1.8/clang+llvm-20.1.8-${arch}-apple-darwin.tar.xz
     tar xf clang+llvm-20.1.8-${arch}-apple-darwin.tar.xz
-    ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/llvm-config llvm-config-19
-    ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/clang clang-19
+    ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/llvm-config llvm-config-20
+    ln -s clang+llvm-20.1.8-${arch}-apple-darwin/bin/clang clang-20
     export CMAKE_PREFIX_PATH=$PWD/clang+llvm-20.1.8-${arch}-apple-darwin
   elif [[ $LLVM_VERSION = 19 ]]; then
     curl -L -O https://github.com/terralang/llvm-build/releases/download/llvm-19.1.7/clang+llvm-19.1.7-${arch}-apple-darwin.tar.xz

--- a/travis.sh
+++ b/travis.sh
@@ -232,8 +232,8 @@ if [[ $(uname) != Darwin ]]; then
     popd
 fi
 
-# Only deploy builds with LLVM 21.
-if [[ $LLVM_VERSION = 21 && ( ! ( $(uname) == MINGW* ) && $USE_CUDA -eq 1 ) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
+# Only deploy builds with LLVM 21 (macOS) and 20 (Windows).
+if [[ (( $(uname) == Darwin && $LLVM_VERSION = 21 ) || ( $(uname) == MINGW* && $LLVM_VERSION = 20 && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
   RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-${arch}-`git rev-parse --short HEAD`
   mv install $RELEASE_NAME
   if [[ $(uname) = MINGW* ]]; then


### PR DESCRIPTION
Based on https://github.com/terralang/terra/pull/697 and https://github.com/terralang/terra/pull/684.

Everything is fixed now on macOS/Linux/FreeBSD. Windows works with LLVM 20 but fails tests with LLVM 21.

Windows required the addition of a [patch to LLVM](https://github.com/terralang/llvm-build/blob/921ec0456f46851f1a3d0a73bbea7d709f91c6a9/patches/remove-clang-abi-from-attrs-clang-trunk.patch) which we'll live with for now. Hopefully at some point we get a proper fix for https://github.com/llvm/llvm-project/issues/163349 and then can remove the patch. See also discussion in https://github.com/elliottslaughter/terra/pull/3