### PR TITLE
Fix LLVM 21 on Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,10 +56,6 @@ jobs:
           - os: 'macos-15'
             llvm: '15'
 
-          # Windows: LLVM 21 is broken
-          - os: 'windows-2022'
-            llvm: '21'
-
           # CUDA: only LLVM 11
           - llvm: '12'
             cuda: '1'

--- a/release/share/terra/README.md
+++ b/release/share/terra/README.md
@@ -124,24 +124,24 @@ If the binary releases are not appropriate, then you can also build Terra from s
 On recent versions of Ubuntu, you can get these dependencies with:
 
 ```
-sudo apt-get install build-essential cmake git llvm-18-dev libclang-18-dev clang-18 libmlir-18-dev libedit-dev libncurses5-dev zlib1g-dev libpfm4-dev
+sudo apt-get install build-essential cmake git llvm-21-dev libclang-21-dev clang-21 libmlir-21-dev libedit-dev libncurses5-dev zlib1g-dev libpfm4-dev
 ```
 
 On macOS with Homebrew, the following should be sufficient:
 
 ```
-brew install cmake llvm@18
+brew install cmake llvm@21
 ```
 
 On FreeBSD, use:
 
 ```
-pkg install -y cmake gmake llvm18
+pkg install -y cmake gmake llvm21
 ```
 
 ### Supported LLVM Versions ###
 
-The current recommended version of LLVM is **20** for most platforms, except Linux (ARM) where LLVM 11 is required. The following versions are also supported:
+The current recommended version of LLVM is **21** for all platforms, except when AMD GPU support is required (see below). The following versions are also supported:
 
 | Version |         Linux |         macOS |       FreeBSD |       Windows |   NVIDIA/CUDA | AMD/HIP \*     | Intel/SPIRV \*\* | Notes |
 | ------- | ------------- | ------------- | ------------- | ------------- | ------------- | -------------- | ---------------- | ----- |
@@ -153,11 +153,11 @@ The current recommended version of LLVM is **20** for most platforms, except Lin
 |      16 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |   :yellow_heart: | |
 |      17 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |    :green_heart: | |
 |      18 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
-|      19 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
+|      19 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |    :green_heart: | |
 |      20 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: |  :green_heart: |    :green_heart: | |
-|      21 | :green_heart: | :green_heart: | :green_heart: |               | :green_heart: |  :green_heart: |    :green_heart: | |
+|      21 | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :green_heart: | :yellow_heart: |    :green_heart: | |
 
-\* AMD GPU support is currently experimental. LLVM 20 is **strongly** recommended.
+\* AMD GPU support is currently experimental. Note that the LLVM version must match the specific ROCm/HIP toolchain version. ROCm/HIP version 6.x requires LLVM 18, 7.0 requires LLVM 20.
 
 \*\* Intel GPU (SPIR-V) support is currently experimental.
 

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -523,6 +523,18 @@ struct CopyConnectedComponent : public ValueMaterializer {
     }
 };
 
+// CloneFunctionInto always inserts an llvm.dbg.cu node into the destination
+// module, even when the function it clones carries no debug info, which leaves
+// an empty node behind. As of LLVM 21 the AsmPrinter takes the mere presence of
+// llvm.dbg.cu on a Windows target as a cue to emit CodeView compiler
+// information, and CodeViewDebug::beginModule then reads the node's first
+// operand -- out of bounds when the node is empty, so it crashes on whatever
+// garbage it picks up. Drop the node rather than leave that landmine behind.
+static void llvmutil_removeemptydebugcus(llvm::Module *M) {
+    NamedMDNode *CUs = M->getNamedMetadata("llvm.dbg.cu");
+    if (CUs && CUs->getNumOperands() == 0) M->eraseNamedMetadata(CUs);
+}
+
 llvm::Module *llvmutil_extractmodulewithproperties(
         llvm::StringRef DestName, llvm::Module *Src, llvm::GlobalValue **gvs, size_t N,
         llvmutil_Property copyGlobal, void *data, llvm::ValueToValueMapTy &VMap) {
@@ -532,6 +544,7 @@ llvm::Module *llvmutil_extractmodulewithproperties(
     cp.CopyDebugMetadata();
     for (size_t i = 0; i < N; i++) MapValue(gvs[i], VMap, RF_None, NULL, &cp);
     cp.finalize();
+    llvmutil_removeemptydebugcus(Dest);
     return Dest;
 }
 void llvmutil_copyfrommodule(llvm::Module *Dest, llvm::Module *Src,
@@ -540,6 +553,7 @@ void llvmutil_copyfrommodule(llvm::Module *Dest, llvm::Module *Src,
     llvm::ValueToValueMapTy VMap;
     CopyConnectedComponent cp(Dest, Src, copyGlobal, data, VMap);
     for (size_t i = 0; i < N; i++) MapValue(gvs[i], VMap, RF_None, NULL, &cp);
+    llvmutil_removeemptydebugcus(Dest);
 }
 
 void llvmutil_optimizemodule(Module *M, TargetMachine *TM) {

--- a/travis.sh
+++ b/travis.sh
@@ -232,8 +232,8 @@ if [[ $(uname) != Darwin ]]; then
     popd
 fi
 
-# Only deploy builds with LLVM 21 (macOS) and 20 (Windows).
-if [[ (( $(uname) == Darwin && $LLVM_VERSION = 21 ) || ( $(uname) == MINGW* && $LLVM_VERSION = 20 && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
+# Only deploy builds with LLVM 21.
+if [[ $LLVM_VERSION = 21 && ( $(uname) == Darwin || ( $(uname) == MINGW* && $USE_CUDA -eq 1 )) && $SLIB_INCLUDE_LLVM -eq 1 && $TERRA_LUA = luajit ]]; then
   RELEASE_NAME=terra-`uname | sed -e s/Darwin/OSX/ | sed -e s/MINGW.*/Windows/`-${arch}-`git rev-parse --short HEAD`
   mv install $RELEASE_NAME
   if [[ $(uname) = MINGW* ]]; then


### PR DESCRIPTION
From Claude:

> CloneFunctionInto always inserts an llvm.dbg.cu node into the destination
> module, even when the function it clones carries no debug info, which leaves
> an empty node behind. As of LLVM 21 the AsmPrinter takes the mere presence of
> llvm.dbg.cu on a Windows target as a cue to emit CodeView compiler
> information, and CodeViewDebug::beginModule then reads the node's first
> operand -- out of bounds when the node is empty, so it crashes on whatever
> garbage it picks up. Drop the node rather than leave that landmine behind.
