### PR TITLE
Fixes for the x86-64 and AArch64 C calling conventions

### DIFF
--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1162,13 +1162,7 @@ struct CCallingConv {
                 int64_t nregs = (bits + regbits - 1) / regbits;
                 Type *regtype = Type::getIntNTy(*CU->TT->ctx, regbits);
                 if (nregs > 1) {
-                    // The aggregate has to stay a single argument in the LLVM
-                    // signature. AAPCS never splits one across the register/stack
-                    // boundary: if the registers left cannot hold all of it, the
-                    // whole thing goes on the stack. Handing LLVM one argument per
-                    // register would instead let it fill the last free register and
-                    // spill only the tail, so an argument list that runs out of
-                    // registers part way through an aggregate would disagree with C.
+                    // Multi-register values must be passed as a single argument.
                     return Argument(C_ARRAY_REG, t, ArrayType::get(regtype, nregs));
                 }
                 // One register, or none at all for an empty aggregate.

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -837,6 +837,7 @@ struct CCallingConv {
     bool ppc64_count_used;
     bool spirv_cconv;
     bool wasm_cconv;
+    bool x86_64_sysv_cconv;
 
     CCallingConv(TerraCompilationUnit *CU_, Types *Ty_)
             : CU(CU_),
@@ -852,9 +853,16 @@ struct CCallingConv {
               ppc64_int_limit(0),
               ppc64_count_used(false),
               spirv_cconv(false),
-              wasm_cconv(false) {
+              wasm_cconv(false),
+              x86_64_sysv_cconv(false) {
         auto Triple = CU->TT->tm->getTargetTriple();
         switch (Triple.getArch()) {
+            case Triple::ArchType::x86_64: {
+                // Only SysV has a limited pool of argument registers that we have
+                // to track. Win64 puts everything past the first four arguments on
+                // the stack, which LLVM already models on its own.
+                x86_64_sysv_cconv = !Triple.isOSWindows();
+            } break;
             case Triple::ArchType::amdgcn: {
                 return_empty_struct_as_void = true;
                 amdgpu_cconv = true;
@@ -1210,7 +1218,32 @@ struct CCallingConv {
         int nfloat = (classes[0] == C_SSE_FLOAT || classes[0] == C_SSE_DOUBLE) +
                      (classes[1] == C_SSE_FLOAT || classes[1] == C_SSE_DOUBLE);
         int nint = (classes[0] == C_INTEGER) + (classes[1] == C_INTEGER);
-        if (sz > 8 && (*usedfloat + nfloat > 8 || *usedint + nint > 6)) {
+        // SysV provides 6 integer and 8 SSE registers for arguments. The counters
+        // can run past those limits, because scalars keep being counted after the
+        // registers are gone, so clamp before asking how many are left.
+        int freefloat = std::max(0, 8 - *usedfloat);
+        int freeint = std::max(0, 6 - *usedint);
+        bool fits = nfloat <= freefloat && nint <= freeint;
+
+        // An aggregate that does not fit in the registers still free is passed on
+        // the stack instead. The counters are deliberately left alone in that case,
+        // so a later, smaller argument can still be passed in registers. Return
+        // values use a dedicated set of registers and never spill, so they are
+        // exempt. Targets other than x86-64 land here with a classification that is
+        // only an approximation of their ABI, so only reconsider the aggregates
+        // they already used to reject (those needing more than one eightbyte).
+        if (!isreturn && !fits && (x86_64_sysv_cconv || sz > 8)) {
+            // Clang avoids byval when no integer register is left to hold the
+            // pointer: an aggregate occupying a single eightbyte is coerced to an
+            // integer of the same size and passed directly, which puts it on the
+            // stack all the same (see X86_64ABIInfo::getIndirectResult). Note the
+            // coercion is to an integer even for the SSE classes. We have to make
+            // the same choice here, or Terra and C disagree on the stack layout.
+            if (x86_64_sysv_cconv && freeint == 0 && sz <= 8 &&
+                CU->getDataLayout().getABITypeAlign(t->type).value() <= 8) {
+                return Argument(C_AGGREGATE_REG, t,
+                                StructType::get(TypeForClass(sz, C_INTEGER)));
+            }
             return Argument(C_AGGREGATE_MEM, t);
         }
 

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -1159,8 +1159,20 @@ struct CCallingConv {
                 // Return values are not padded, so they fall through below.
                 int64_t regbits = align > 64 ? 128 : 64;
                 int64_t bits = CU->getDataLayout().getTypeAllocSizeInBits(t->type);
-                std::vector<Type *> elements((bits + regbits - 1) / regbits,
-                                             Type::getIntNTy(*CU->TT->ctx, regbits));
+                int64_t nregs = (bits + regbits - 1) / regbits;
+                Type *regtype = Type::getIntNTy(*CU->TT->ctx, regbits);
+                if (nregs > 1) {
+                    // The aggregate has to stay a single argument in the LLVM
+                    // signature. AAPCS never splits one across the register/stack
+                    // boundary: if the registers left cannot hold all of it, the
+                    // whole thing goes on the stack. Handing LLVM one argument per
+                    // register would instead let it fill the last free register and
+                    // spill only the tail, so an argument list that runs out of
+                    // registers part way through an aggregate would disagree with C.
+                    return Argument(C_ARRAY_REG, t, ArrayType::get(regtype, nregs));
+                }
+                // One register, or none at all for an empty aggregate.
+                std::vector<Type *> elements(nregs, regtype);
                 return Argument(C_AGGREGATE_REG, t,
                                 StructType::get(*CU->TT->ctx, elements));
             }
@@ -1496,17 +1508,11 @@ struct CCallingConv {
                     }
                 } break;
                 case C_ARRAY_REG: {
-                    Value *scratch = CreateAlloca(B, p->cctype);
-                    emitStoreAgg(B, p->cctype, &*ai, scratch);
-#if LLVM_VERSION < 170
-                    unsigned as = scratch->getType()->getPointerAddressSpace();
-                    Value *casted = B->CreateBitCast(scratch, Ptr(p->type->type, as));
+                    Value *scratch = CreateCoercionAlloca(B, p->type->type, p->cctype);
+                    emitStoreAgg(B, p->cctype, &*ai, CoercionPtr(B, scratch, p->cctype));
+                    Value *casted = CoercionPtr(B, scratch, p->type->type);
                     emitStoreAgg(B, p->type->type, B->CreateLoad(p->type->type, casted),
                                  v);
-#else
-                    emitStoreAgg(B, p->type->type, B->CreateLoad(p->type->type, scratch),
-                                 v);
-#endif
                     ++ai;
                 } break;
             }
@@ -1603,15 +1609,11 @@ struct CCallingConv {
                                    arguments);
                 } break;
                 case C_ARRAY_REG: {
-                    Value *scratch = CreateAlloca(B, a->type->type);
-                    emitStoreAgg(B, a->type->type, actual, scratch);
-#if LLVM_VERSION < 170
-                    unsigned as = scratch->getType()->getPointerAddressSpace();
-                    Value *casted = B->CreateBitCast(scratch, Ptr(a->cctype, as));
-                    EmitCallAggReg(B, casted, a->cctype, arguments);
-#else
-                    EmitCallAggReg(B, scratch, a->cctype, arguments);
-#endif
+                    Value *scratch = CreateCoercionAlloca(B, a->type->type, a->cctype);
+                    emitStoreAgg(B, a->type->type, actual,
+                                 CoercionPtr(B, scratch, a->type->type));
+                    EmitCallAggReg(B, CoercionPtr(B, scratch, a->cctype), a->cctype,
+                                   arguments);
                 } break;
                 default: {
                     assert(!"unhandled argument kind");

--- a/tests/cconv.t
+++ b/tests/cconv.t
@@ -486,3 +486,214 @@ test.meq({8,7},c2())
 test.meq({4,3,4},c3())
 test.meq({4.25,3.25,4.25},c4())
 test.meq({1,0,1,8,3},c5())
+
+
+-- Argument register exhaustion.
+--
+-- These cases have to cross into C. A Terra-to-Terra call agrees with itself no
+-- matter how its arguments get classified, so only calling a Clang-compiled
+-- function (or being called by one) can catch a disagreement about which
+-- arguments travel in registers and which are passed on the stack.
+--
+-- Each test sits exactly on the boundary where one of the register files runs
+-- out, which is where x86-64 SysV is easiest to get wrong. See
+-- https://github.com/terralang/terra/issues/576. The exhaustive version of this
+-- lives in cconv_more.t and cconv_fuzz.t; what is here is the short list worth
+-- checking on every run.
+--
+-- Every scalar slot gets a distinct value (1, 2, 3, ...) and the C side returns
+-- a weighted sum, so a dropped, duplicated, or reordered argument all show up.
+
+local cc = terralib.includecstring [[
+#include <stdint.h>
+
+typedef struct CF2 { float a; float b; } CF2;                 /* one SSE eightbyte */
+typedef struct CI1 { int64_t a; } CI1;                        /* one INTEGER eightbyte */
+typedef struct CU1 { uint8_t a; } CU1;                        /* one byte, coerces to i8 */
+typedef struct CU3 { uint8_t a; uint8_t b; uint8_t c; } CU3;  /* three bytes, coerces to i24 */
+typedef struct CIF { int32_t a; float b; } CIF;               /* mixed, one INTEGER eightbyte */
+typedef struct CD2 { double a; double b; } CD2;               /* two SSE eightbytes */
+typedef struct CBIG { int64_t a; int64_t b; int64_t c; int64_t d; } CBIG;
+
+/* The 8 SSE registers are used up by the first 8 aggregates, so the 9th and 10th
+   go on the stack even though integer registers are still free.
+
+   Two of them have to spill, not one: a stack slot for an SSE eightbyte is 8
+   bytes wide, but a <2 x float> passed the same way takes 16, so a lone spilled
+   argument still lands at the right offset and only the one after it moves. */
+__attribute__ ((noinline)) double sse_spill(
+    CF2 x1, CF2 x2, CF2 x3, CF2 x4, CF2 x5,
+    CF2 x6, CF2 x7, CF2 x8, CF2 x9, CF2 x10) {
+  return 1*x1.a + 2*x1.b + 3*x2.a + 4*x2.b + 5*x3.a + 6*x3.b
+       + 7*x4.a + 8*x4.b + 9*x5.a + 10*x5.b + 11*x6.a + 12*x6.b
+       + 13*x7.a + 14*x7.b + 15*x8.a + 16*x8.b + 17*x9.a + 18*x9.b
+       + 19*x10.a + 20*x10.b;
+}
+
+/* The 6 integer registers are gone after the 6th aggregate. Clang does not use
+   byval here: with no integer register left to hold a pointer it coerces the
+   aggregate to an integer of the same size and lets that land on the stack. */
+__attribute__ ((noinline)) double int_spill(
+    CI1 x1, CI1 x2, CI1 x3, CI1 x4, CI1 x5, CI1 x6, CI1 x7) {
+  return 1*x1.a + 2*x2.a + 3*x3.a + 4*x4.a + 5*x5.a + 6*x6.a + 7*x7.a;
+}
+
+/* Same, at sizes that are not a whole eightbyte: these coerce to i8 and i24. */
+__attribute__ ((noinline)) double int_spill_i8(
+    CU1 x1, CU1 x2, CU1 x3, CU1 x4, CU1 x5, CU1 x6, CU1 x7) {
+  return 1*x1.a + 2*x2.a + 3*x3.a + 4*x4.a + 5*x5.a + 6*x6.a + 7*x7.a;
+}
+
+__attribute__ ((noinline)) double int_spill_i24(
+    CU3 x1, CU3 x2, CU3 x3, CU3 x4, CU3 x5, CU3 x6, CU3 x7) {
+  return 1*x1.a + 2*x1.b + 3*x1.c + 4*x2.a + 5*x2.b + 6*x2.c
+       + 7*x3.a + 8*x3.b + 9*x3.c + 10*x4.a + 11*x4.b + 12*x4.c
+       + 13*x5.a + 14*x5.b + 15*x5.c + 16*x6.a + 17*x6.b + 18*x6.c
+       + 19*x7.a + 20*x7.b + 21*x7.c;
+}
+
+/* A struct of mixed class that still occupies a single INTEGER eightbyte. */
+__attribute__ ((noinline)) double int_spill_mixed(
+    CIF x1, CIF x2, CIF x3, CIF x4, CIF x5, CIF x6, CIF x7) {
+  return 1*x1.a + 2*x1.b + 3*x2.a + 4*x2.b + 5*x3.a + 6*x3.b
+       + 7*x4.a + 8*x4.b + 9*x5.a + 10*x5.b + 11*x6.a + 12*x6.b
+       + 13*x7.a + 14*x7.b;
+}
+
+/* Both register files are exhausted before the aggregate. The coercion is to an
+   integer even though the aggregate is SSE classed. */
+__attribute__ ((noinline)) double both_spill(
+    int64_t i1, int64_t i2, int64_t i3, int64_t i4, int64_t i5, int64_t i6,
+    double d1, double d2, double d3, double d4,
+    double d5, double d6, double d7, double d8, CF2 x, CF2 y) {
+  return 1*i1 + 2*i2 + 3*i3 + 4*i4 + 5*i5 + 6*i6
+       + 7*d1 + 8*d2 + 9*d3 + 10*d4 + 11*d5 + 12*d6 + 13*d7 + 14*d8
+       + 15*x.a + 16*x.b + 17*y.a + 18*y.b;
+}
+
+/* The returned struct is too big for registers, so a hidden pointer takes the
+   first integer register and only five are left for i1..i6. The aggregate needs
+   no integer register at all, though, so it still travels in SSE registers. */
+__attribute__ ((noinline)) CBIG sret_and_int_spill(
+    int64_t i1, int64_t i2, int64_t i3, int64_t i4, int64_t i5, int64_t i6,
+    CD2 x) {
+  double t = 1*i1 + 2*i2 + 3*i3 + 4*i4 + 5*i5 + 6*i6 + 7*x.a + 8*x.b;
+  CBIG r;
+  r.a = (int64_t)t; r.b = 2*(int64_t)t; r.c = 3*(int64_t)t; r.d = 4*(int64_t)t;
+  return r;
+}
+
+/* An argument that spills does not consume a register, so the trailing integer
+   still arrives in one. */
+__attribute__ ((noinline)) double spill_then_reg(
+    double d1, double d2, double d3, double d4,
+    double d5, double d6, double d7, double d8, CF2 x, CF2 y, int32_t n) {
+  return 1*d1 + 2*d2 + 3*d3 + 4*d4 + 5*d5 + 6*d6 + 7*d7 + 8*d8
+       + 9*x.a + 10*x.b + 11*y.a + 12*y.b + 13*n;
+}
+
+/* The reverse direction: C calls a Terra function whose arguments spill. This
+   checks how Terra defines such a function, not just how it calls one. */
+typedef double (*sse_spill_fn)(CF2, CF2, CF2, CF2, CF2, CF2, CF2, CF2, CF2, CF2);
+__attribute__ ((noinline)) double call_sse_spill(sse_spill_fn f) {
+  CF2 a1 = {1,2}, a2 = {3,4}, a3 = {5,6}, a4 = {7,8}, a5 = {9,10};
+  CF2 a6 = {11,12}, a7 = {13,14}, a8 = {15,16}, a9 = {17,18}, a10 = {19,20};
+  return f(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10);
+}
+
+typedef double (*int_spill_fn)(CI1, CI1, CI1, CI1, CI1, CI1, CI1);
+__attribute__ ((noinline)) double call_int_spill(int_spill_fn f) {
+  CI1 a1 = {1}, a2 = {2}, a3 = {3}, a4 = {4}, a5 = {5}, a6 = {6}, a7 = {7};
+  return f(a1, a2, a3, a4, a5, a6, a7);
+}
+]]
+
+-- Sum of i*i for i = 1..n, which is what each weighted sum above comes to when
+-- slot i holds the value i.
+local function sumsq(n)
+	local s = 0
+	for i = 1, n do s = s + i * i end
+	return s
+end
+
+terra c25()
+	return cc.sse_spill(
+		cc.CF2 { 1, 2 }, cc.CF2 { 3, 4 }, cc.CF2 { 5, 6 },
+		cc.CF2 { 7, 8 }, cc.CF2 { 9, 10 }, cc.CF2 { 11, 12 },
+		cc.CF2 { 13, 14 }, cc.CF2 { 15, 16 }, cc.CF2 { 17, 18 },
+		cc.CF2 { 19, 20 })
+end
+test.eq(c25(), sumsq(20))
+
+terra c26()
+	return cc.int_spill(
+		cc.CI1 { 1 }, cc.CI1 { 2 }, cc.CI1 { 3 }, cc.CI1 { 4 },
+		cc.CI1 { 5 }, cc.CI1 { 6 }, cc.CI1 { 7 })
+end
+test.eq(c26(), sumsq(7))
+
+terra c27()
+	return cc.int_spill_i8(
+		cc.CU1 { 1 }, cc.CU1 { 2 }, cc.CU1 { 3 }, cc.CU1 { 4 },
+		cc.CU1 { 5 }, cc.CU1 { 6 }, cc.CU1 { 7 })
+end
+test.eq(c27(), sumsq(7))
+
+terra c28()
+	return cc.int_spill_i24(
+		cc.CU3 { 1, 2, 3 }, cc.CU3 { 4, 5, 6 }, cc.CU3 { 7, 8, 9 },
+		cc.CU3 { 10, 11, 12 }, cc.CU3 { 13, 14, 15 }, cc.CU3 { 16, 17, 18 },
+		cc.CU3 { 19, 20, 21 })
+end
+test.eq(c28(), sumsq(21))
+
+terra c29()
+	return cc.int_spill_mixed(
+		cc.CIF { 1, 2 }, cc.CIF { 3, 4 }, cc.CIF { 5, 6 }, cc.CIF { 7, 8 },
+		cc.CIF { 9, 10 }, cc.CIF { 11, 12 }, cc.CIF { 13, 14 })
+end
+test.eq(c29(), sumsq(14))
+
+terra c30()
+	return cc.both_spill(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14,
+		cc.CF2 { 15, 16 }, cc.CF2 { 17, 18 })
+end
+test.eq(c30(), sumsq(18))
+
+terra c31()
+	var r = cc.sret_and_int_spill(1, 2, 3, 4, 5, 6, cc.CD2 { 7, 8 })
+	return double(r.a + r.b + r.c + r.d)
+end
+-- The callee returns t, 2t, 3t and 4t, so the four fields sum to 10t.
+test.eq(c31(), 10 * sumsq(8))
+
+terra c32()
+	return cc.spill_then_reg(1, 2, 3, 4, 5, 6, 7, 8,
+		cc.CF2 { 9, 10 }, cc.CF2 { 11, 12 }, 13)
+end
+test.eq(c32(), sumsq(13))
+
+terra f33(x1 : cc.CF2, x2 : cc.CF2, x3 : cc.CF2, x4 : cc.CF2, x5 : cc.CF2,
+          x6 : cc.CF2, x7 : cc.CF2, x8 : cc.CF2, x9 : cc.CF2, x10 : cc.CF2) : double
+	return 1*x1.a + 2*x1.b + 3*x2.a + 4*x2.b + 5*x3.a + 6*x3.b
+	     + 7*x4.a + 8*x4.b + 9*x5.a + 10*x5.b + 11*x6.a + 12*x6.b
+	     + 13*x7.a + 14*x7.b + 15*x8.a + 16*x8.b + 17*x9.a + 18*x9.b
+	     + 19*x10.a + 20*x10.b
+end
+f33:setinlined(false)
+
+terra c33()
+	return cc.call_sse_spill(f33)
+end
+test.eq(c33(), sumsq(20))
+
+terra f34(x1 : cc.CI1, x2 : cc.CI1, x3 : cc.CI1, x4 : cc.CI1, x5 : cc.CI1,
+          x6 : cc.CI1, x7 : cc.CI1) : double
+	return 1*x1.a + 2*x2.a + 3*x3.a + 4*x4.a + 5*x5.a + 6*x6.a + 7*x7.a
+end
+f34:setinlined(false)
+
+terra c34()
+	return cc.call_int_spill(f34)
+end
+test.eq(c34(), sumsq(7))

--- a/tests/cconv_fuzz.t
+++ b/tests/cconv_fuzz.t
@@ -1,0 +1,358 @@
+-- A randomized differential test for the C calling convention.
+--
+-- Each run builds a batch of C functions with randomly shaped signatures --
+-- scalars and aggregates interleaved, with and without a struct return -- and
+-- then calls each one from Terra and checks the answer. Terra and Clang have to
+-- agree about which arguments travel in registers and which are passed on the
+-- stack; where they disagree, the callee reads the wrong slots and the result
+-- comes out wrong.
+--
+-- This complements the other two calling convention tests. cconv.t is a fixed
+-- list of hand-picked corner cases and cconv_more.t is a systematic sweep over
+-- argument counts and types, but both only ever vary one thing at a time. What
+-- historically broke is the interleavings: mixed sequences where one register
+-- file runs out well before the other, and where an argument that spilled to
+-- the stack must not consume a register that a later argument still needs.
+-- See https://github.com/terralang/terra/issues/576.
+--
+-- Roughly a third of the signatures are also exercised in the opposite
+-- direction, with C calling a Terra function, which checks how Terra *defines*
+-- such a function rather than only how it calls one.
+
+-- Tuning. NUM_FUNCTIONS is chosen to keep the test to a minute or two; raise it,
+-- or change SEED, to search harder when working on the calling convention.
+local MAX_N = 14        -- longest argument list to generate
+local NUM_FUNCTIONS = 7000
+local SEED = 1
+
+-- The batch has to come out identical on every platform and every Lua version,
+-- so use an explicit PRNG (MINSTD) rather than math.random, whose sequence is
+-- not guaranteed to be reproducible. All products stay under 2^53, so the
+-- arithmetic is exact in a double.
+assert(SEED >= 1 and SEED < 2147483647, "seed must be in [1, 2^31-1)")
+local rand_state = SEED
+local function rand(n)
+  rand_state = (rand_state * 16807) % 2147483647
+  return rand_state % n + 1
+end
+
+local scalar_types = {
+  {c = "int8_t", t = int8},
+  {c = "int16_t", t = int16},
+  {c = "int32_t", t = int32},
+  {c = "int64_t", t = int64},
+  {c = "float", t = float},
+  {c = "double", t = double},
+}
+
+-- Fields are described structurally rather than as C source, so that the C
+-- declaration, the C accessor expressions and the Terra accessor expressions can
+-- all be generated from one description and cannot drift apart.
+local function fld(name, ctype) return {name = name, ctype = ctype} end
+local function arr(name, ctype, n) return {name = name, ctype = ctype, n = n} end
+local function sub(name, ctype, fields)
+  return {name = name, ctype = ctype, fields = fields}
+end
+
+-- A nested struct, to cover aggregates that need a recursive walk to classify.
+local nested_decl = "typedef struct NPair { int32_t x; int32_t y; } NPair;"
+local nested_fields = {fld("x", "int32_t"), fld("y", "int32_t")}
+
+-- Shapes spanning the classifications that matter on x86-64: one eightbyte and
+-- two, INTEGER and SSE and mixed, sizes that are not a whole eightbyte, arrays
+-- and nested structs, and some too large for registers at all.
+local agg_types = {
+  {name = "A1", fields = {fld("a", "uint8_t")}},
+  {name = "A2", fields = {fld("a", "uint8_t"), fld("b", "uint8_t"), fld("c", "uint8_t")}},
+  {name = "A3", fields = {fld("a", "int16_t")}},
+  {name = "A4", fields = {fld("a", "int32_t"), fld("b", "int32_t")}},
+  {name = "A5", fields = {fld("a", "int64_t")}},
+  {name = "A6", fields = {fld("a", "int64_t"), fld("b", "int64_t")}},
+  {name = "A7", fields = {fld("a", "int64_t"), fld("b", "int64_t"), fld("c", "int64_t")}},
+  {name = "A8", fields = {fld("a", "float")}},
+  {name = "A9", fields = {fld("a", "float"), fld("b", "float")}},
+  {name = "A10", fields = {fld("a", "float"), fld("b", "float"), fld("c", "float")}},
+  {name = "A11", fields = {arr("a", "float", 4)}},
+  {name = "A12", fields = {fld("a", "double")}},
+  {name = "A13", fields = {fld("a", "double"), fld("b", "double")}},
+  {name = "A14", fields = {arr("a", "double", 3)}},
+  {name = "A15", fields = {fld("a", "int32_t"), fld("b", "float")}},
+  {name = "A16", fields = {fld("a", "double"), fld("b", "int64_t")}},
+  {name = "A17", fields = {fld("a", "int8_t"), fld("b", "double")}},
+  {name = "A18", fields = {fld("a", "float"), fld("b", "int64_t")}},
+  {name = "A19", fields = {fld("a", "int32_t"), fld("b", "double"), fld("c", "double")}},
+  {name = "A20", fields = {arr("a", "uint8_t", 3)}},
+  {name = "A21", fields = {arr("a", "float", 2)}},
+  {name = "A22", fields = {arr("a", "double", 2), fld("b", "int32_t")}},
+  {name = "A23", fields = {sub("a", "NPair", nested_fields), fld("b", "float")}},
+  {name = "A24", fields = {fld("a", "int8_t"), sub("b", "NPair", nested_fields)}},
+}
+
+-- Values are kept small so they fit every scalar type down to int8, and the
+-- weights are the slot numbers, so a dropped, duplicated or reordered argument
+-- all change the sum. Two slots would have to be 100 apart to collide, which
+-- cannot happen at these argument counts.
+local function slot_value(k) return (k - 1) % 100 + 1 end
+
+local function decl_field(f, out)
+  if f.n then
+    out:insert(f.ctype .. " " .. f.name .. "[" .. f.n .. "];")
+  else
+    out:insert(f.ctype .. " " .. f.name .. ";")
+  end
+end
+
+-- Accessor suffixes for every scalar slot in a shape, in declaration order.
+local function paths_of(fields, prefix, out)
+  for _, f in ipairs(fields) do
+    if f.fields then
+      paths_of(f.fields, prefix .. "." .. f.name, out)
+    elseif f.n then
+      for i = 0, f.n - 1 do
+        out:insert(prefix .. "." .. f.name .. "[" .. i .. "]")
+      end
+    else
+      out:insert(prefix .. "." .. f.name)
+    end
+  end
+  return out
+end
+
+for _, agg in ipairs(agg_types) do
+  agg.paths = paths_of(agg.fields, "", terralib.newlist())
+end
+
+-- Pick every signature up front, so the C source and the Terra side are built
+-- from exactly the same description.
+local sigs = terralib.newlist()
+for i = 1, NUM_FUNCTIONS do
+  local args = terralib.newlist()
+  for _ = 1, rand(MAX_N) do
+    if rand(100) <= 45 then
+      args:insert({kind = "scalar", info = scalar_types[rand(#scalar_types)]})
+    else
+      args:insert({kind = "agg", info = agg_types[rand(#agg_types)]})
+    end
+  end
+  -- Half return a struct too big for registers, which puts a hidden pointer in
+  -- the first integer register and shifts everything that follows.
+  local sret = rand(2) == 1
+  sigs:insert({
+    name = "fn" .. i,
+    args = args,
+    sret = sret,
+    -- Only the plain-double signatures are run in reverse, to keep the C side
+    -- simple; the sret ones are already covered in the forward direction.
+    reverse = not sret and rand(3) == 1,
+  })
+end
+
+-- Scalar slots of one signature, as {weight, accessor} against argument names
+-- x1, x2, ... The weight is just the slot number.
+local function slots_of(sig)
+  local out = terralib.newlist()
+  for i, arg in ipairs(sig.args) do
+    if arg.kind == "scalar" then
+      out:insert({w = #out + 1, expr = "x" .. i})
+    else
+      for _, p in ipairs(arg.info.paths) do
+        out:insert({w = #out + 1, expr = "x" .. i .. p})
+      end
+    end
+  end
+  return out
+end
+
+local function params_of(sig)
+  local out = terralib.newlist()
+  for i, arg in ipairs(sig.args) do
+    out:insert((arg.kind == "scalar" and arg.info.c or arg.info.name) .. " x" .. i)
+  end
+  return out
+end
+
+local function expected_of(sig)
+  local total = 0
+  for _, s in ipairs(slots_of(sig)) do total = total + s.w * slot_value(s.w) end
+  return total
+end
+
+local defs = terralib.newlist({"#include <stdint.h>", "", nested_decl})
+for _, agg in ipairs(agg_types) do
+  local parts = terralib.newlist({"typedef struct " .. agg.name .. " {"})
+  for _, f in ipairs(agg.fields) do decl_field(f, parts) end
+  parts:insert("} " .. agg.name .. ";")
+  defs:insert(parts:concat(" "))
+end
+defs:insert("typedef struct BigRet { int64_t a, b, c, d; } BigRet;")
+defs:insert("")
+
+for _, sig in ipairs(sigs) do
+  local sums = terralib.newlist()
+  for _, s in ipairs(slots_of(sig)) do
+    sums:insert(s.w .. "*(double)" .. s.expr)
+  end
+  local sum = #sums > 0 and sums:concat(" + ") or "0"
+  local params = params_of(sig):concat(", ")
+  if sig.sret then
+    -- Spread the answer over all four fields so a botched sret shows up.
+    defs:insert("__attribute__ ((noinline)) BigRet " .. sig.name .. "(" .. params ..
+                ") { double t = " .. sum .. "; BigRet r; r.a = (int64_t)t;" ..
+                " r.b = 2*(int64_t)t; r.c = 3*(int64_t)t; r.d = 4*(int64_t)t;" ..
+                " return r; }")
+  else
+    defs:insert("__attribute__ ((noinline)) double " .. sig.name .. "(" .. params ..
+                ") { return " .. sum .. "; }")
+  end
+  if sig.reverse then
+    -- The wrapper takes the same arguments and forwards them, so one function
+    -- covers both directions: Terra calls it, and it calls back into Terra.
+    local types, names = terralib.newlist(), terralib.newlist()
+    for i, arg in ipairs(sig.args) do
+      types:insert(arg.kind == "scalar" and arg.info.c or arg.info.name)
+      names:insert("x" .. i)
+    end
+    defs:insert("typedef double (*" .. sig.name .. "_t)(" ..
+                (#types > 0 and types:concat(", ") or "void") .. ");")
+    defs:insert("__attribute__ ((noinline)) double call_" .. sig.name .. "(" ..
+                sig.name .. "_t f" .. (#params > 0 and ", " .. params or "") ..
+                ") { return f(" .. names:concat(", ") .. "); }")
+  end
+end
+
+local c = terralib.includecstring(defs:concat("\n"))
+
+-- Terra-side accessor for one scalar slot of an argument.
+local function terra_slots(sig, syms)
+  local out = terralib.newlist()
+  local function walk(expr, fields)
+    for _, f in ipairs(fields) do
+      if f.fields then
+        walk(`expr.[f.name], f.fields)
+      elseif f.n then
+        for i = 0, f.n - 1 do
+          out:insert(`expr.[f.name][i])
+        end
+      else
+        out:insert(`expr.[f.name])
+      end
+    end
+  end
+  for i, arg in ipairs(sig.args) do
+    if arg.kind == "scalar" then
+      out:insert(`[syms[i]])
+    else
+      walk(`[syms[i]], arg.info.fields)
+    end
+  end
+  return out
+end
+
+local function weighted_sum(exprs)
+  local total = `0.0
+  for i, e in ipairs(exprs) do
+    total = `total + [double](i) * [double](e)
+  end
+  return total
+end
+
+-- Build the argument values for a call: every scalar slot gets its own value.
+local function build_args(sig)
+  local stats, argvals = terralib.newlist(), terralib.newlist()
+  local k = 0
+  for i, arg in ipairs(sig.args) do
+    if arg.kind == "scalar" then
+      k = k + 1
+      argvals:insert(`[arg.info.t]([slot_value(k)]))
+    else
+      local sym = terralib.newsymbol(c[arg.info.name], "x" .. i)
+      stats:insert(quote var [sym] end)
+      local function walk(expr, fields)
+        for _, f in ipairs(fields) do
+          if f.fields then
+            walk(`expr.[f.name], f.fields)
+          elseif f.n then
+            for j = 0, f.n - 1 do
+              k = k + 1
+              stats:insert(quote expr.[f.name][j] = [slot_value(k)] end)
+            end
+          else
+            k = k + 1
+            stats:insert(quote expr.[f.name] = [slot_value(k)] end)
+          end
+        end
+      end
+      walk(`[sym], arg.info.fields)
+      argvals:insert(sym)
+    end
+  end
+  return stats, argvals
+end
+
+local failures = 0
+local checked = 0
+
+local function report(sig, direction, got, want)
+  failures = failures + 1
+  local desc = terralib.newlist()
+  for _, arg in ipairs(sig.args) do
+    desc:insert(arg.kind == "scalar" and arg.info.c or arg.info.name)
+  end
+  print(string.format("FAIL %s (%s, sret=%s): got %s, expected %s\n  args: %s",
+                      sig.name, direction, tostring(sig.sret), tostring(got),
+                      tostring(want), desc:concat(", ")))
+end
+
+for _, sig in ipairs(sigs) do
+  local cfunc = c[sig.name]
+  local stats, argvals = build_args(sig)
+  local want = expected_of(sig)
+
+  local forward
+  if sig.sret then
+    forward = terra() : double
+      [stats]
+      var r = cfunc([argvals])
+      return [double](r.a + r.b + r.c + r.d)
+    end
+    want = 10 * want  -- the four fields hold t, 2t, 3t and 4t
+  else
+    forward = terra() : double
+      [stats]
+      return cfunc([argvals])
+    end
+  end
+
+  checked = checked + 1
+  local got = forward()
+  if got ~= want then report(sig, "Terra calls C", got, want) end
+
+  if sig.reverse then
+    local syms = terralib.newlist()
+    for i, arg in ipairs(sig.args) do
+      local typ = arg.kind == "scalar" and arg.info.t or c[arg.info.name]
+      syms:insert(terralib.newsymbol(typ, "x" .. i))
+    end
+    local terra callee([syms]) : double
+      return [weighted_sum(terra_slots(sig, syms))]
+    end
+    callee:setinlined(false)
+
+    local wrapper = c["call_" .. sig.name]
+    local stats2, argvals2 = build_args(sig)
+    local terra reverse() : double
+      [stats2]
+      return wrapper(callee, [argvals2])
+    end
+
+    checked = checked + 1
+    local got2 = reverse()
+    if got2 ~= want then report(sig, "C calls Terra", got2, want) end
+  end
+end
+
+print(string.format("cconv_fuzz: %d checks over %d signatures (seed %d, max %d args)",
+                    checked, #sigs, SEED, MAX_N))
+if failures > 0 then
+  error(string.format("%d of %d calling convention checks failed", failures, checked))
+end

--- a/tests/cconv_more.t
+++ b/tests/cconv_more.t
@@ -36,11 +36,6 @@
 local MAX_N = 12 -- Needs to be <= 23 to avoid overflowing uint8.
 local MAX_ARRAY_N = 4
 
-local ffi = require("ffi")
-if ffi.arch == "x64" then
-  MAX_N = 9 -- https://github.com/terralang/terra/issues/576
-end
-
 local ctypes = {
   [uint8] = "uint8_t",
   [int16] = "int16_t",


### PR DESCRIPTION
This adds:

 * Fixes for the x86-64 calling convention, particular aggregates interleaved with scalars
 * Fixes for the AArch64 calling convention (cases where an aggregate overflows registers)
 * Some new directed tests in `cconv.t` to capture corner cases relevant to x86-64 (mainly)
 * Removes limit on `cconv_more.t`
 * Adds `cconv_fuzz.t` which includes more randomization (e.g., interleaving of scalar and aggregate arguments)

Fixes #576