### PR TITLE
Fix to avoid linking bad LLVM intrinsics from CUDA 12.9 libdevice.bc

### DIFF
--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -154,7 +154,9 @@ void moduleToPTX(terra_State *T, llvm::Module *M, int major, int minor, std::str
     LDEVICE->setDataLayout(TargetMachine->createDataLayout());
 
     llvm::Linker Linker(*M);
-    Linker.linkInModule(std::move(LDEVICE));
+    if (Linker.linkInModule(std::move(LDEVICE), llvm::Linker::Flags::LinkOnlyNeeded)) {
+        assert(false && "failed to link libdevice.bc");
+    }
 
     M->setDataLayout(TargetMachine->createDataLayout());
 


### PR DESCRIPTION
Fixes https://github.com/StanfordLegion/legion/issues/1894 via the suggestion in https://github.com/StanfordLegion/legion/issues/1894#issuecomment-3120662264.