### PR TITLE
Stop relying on LLVM to find CUDA for us

### DIFF
--- a/src/tcwrapper.cpp
+++ b/src/tcwrapper.cpp
@@ -819,8 +819,6 @@ void InitHeaderSearchFlagsAndArgs(std::string const &TripleStr, HeaderSearchOpti
     llvm::opt::ArgStringList IncludeArgs;
     TC.AddClangSystemIncludeArgs(C->getArgs(), IncludeArgs);
 
-    TC.AddCudaIncludeArgs(C->getArgs(), IncludeArgs);
-
     // organized in pairs "-<flag> <directory>"
     assert(((IncludeArgs.size() & 1) == 0) && "even number of IncludeArgs");
     HSO.UserEntries.reserve(IncludeArgs.size() / 2);

--- a/src/terralib.lua
+++ b/src/terralib.lua
@@ -4477,9 +4477,10 @@ if ffi.os == "Windows" then
             return linker,vclib,vcpath
         end
     end
-    if terra.cudahome then
-        terra.systemincludes:insertall{terra.cudahome.."\\include"}
-    end
+end
+if terra.cudahome then
+    local sep = ffi.os == "Windows" and "\\" or "/"
+    terra.systemincludes:insert(terra.cudahome .. sep .. "include")
 end
 
 


### PR DESCRIPTION
In the past we relied on `clang::driver::ToolChain::AddCudaIncludeArgs` to find CUDA for us. However, beginning with LLVM 14, the Clang implementation of this function for `CudaToolChain` started checking for a list of "compatible" toolchains and rejecting ones that don't meet those criteria. Those are, to be clear, compatible *with Clang*. Which is not something we've ever cared about, as we are not using Clang as a CUDA frontend.

Since this is clearly not compatible with our goals, we're ripping this out and doing it ourselves, which apparently we already did on Windows. Now we do it everywhere.

If you have been working around this with `INCLUDE_PATH=$CUDA/include` (or similar), as we have been doing in Regent, you can stop doing that now. Terra will add `$CUDA_HOME/include` to the include path automatically, and will attempt to infer the CUDA location (currently not that smart, but better than LLVM).