### PR TITLE
Update manual inliner for LLVM 17+

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -93,16 +93,11 @@ list(APPEND TERRA_LIB_SRC
   tcuda.cpp        tcuda.h
   tdebug.cpp       tdebug.h
   tinternalizedfiles.cpp
+  tinline.cpp      tinline.h
   lj_strscan.c     lj_strscan.h
 
   ${PROJECT_BINARY_DIR}/include/terra/terra.h
 )
-
-if(LLVM_VERSION_MAJOR LESS 17)
-  list(APPEND TERRA_LIB_SRC
-    tinline.cpp    tinline.h
-  )
-endif()
 
 list(APPEND TERRA_BIN_SRC
   main.cpp
@@ -170,13 +165,6 @@ if(NOT WIN32 AND NOT ${LLVM_ENABLE_RTTI})
     PRIVATE
       # FIXME: Find portable ways to do all these
       $<$<COMPILE_LANGUAGE:CXX>:-fno-rtti>
-  )
-endif()
-
-if(NOT ${LLVM_ENABLE_ASSERTIONS})
-  target_compile_definitions(TerraObjectFiles
-    PRIVATE
-      TERRA_LLVM_HEADERS_HAVE_NDEBUG
   )
 endif()
 

--- a/src/tcompiler.cpp
+++ b/src/tcompiler.cpp
@@ -418,15 +418,17 @@ int terra_initcompilationunit(lua_State *L) {
     CU->M->setDataLayout(TT->tm->createDataLayout());
 
 #if LLVM_VERSION < 170
-    // FIXME (Elliott): need to restore the manual inliner in LLVM 17
     CU->mi = new ManualInliner(TT->tm, CU->M);
     CU->fpm = new FunctionPassManagerT(CU->M);
     llvmutil_addtargetspecificpasses(CU->fpm, TT->tm);
     llvmutil_addoptimizationpasses(CU->fpm);
     CU->fpm->doInitialization();
 #else
+    // Must build the pass manager first: it is what registers the analyses in
+    // the managers the inliner reads from.
     CU->fpm = new FunctionPassManager(llvmutil_createoptimizationpasses(
             TT->tm, CU->lam, CU->fam, CU->cgam, CU->mam));
+    CU->mi = new ManualInliner(TT->tm, CU->M, CU->fam, CU->mam);
 #endif
     lua_pushlightuserdata(L, CU);
     return 1;
@@ -518,10 +520,7 @@ int terra_freetarget(lua_State *L) {
 static void freecompilationunit(TerraCompilationUnit *CU) {
     assert(CU->nreferences > 0);
     if (0 == --CU->nreferences) {
-#if LLVM_VERSION < 170
-        // FIXME (Elliott): need to restore the manual inliner in LLVM 17
         delete CU->mi;
-#endif
         delete CU->fpm;
         if (CU->ee) {
             CU->ee->UnregisterJITEventListener(CU->jiteventlistener);
@@ -2087,10 +2086,7 @@ struct FunctionEmitter {
                             printf("%s%s", s.c_str(), (fstate == f) ? "\n" : " ");
                         }
                     } while (fstate != f);
-#if LLVM_VERSION < 170
-                    // FIXME (Elliott): need to restore the manual inliner in LLVM 17
                     CU->mi->run(scc.begin(), scc.end());
-#endif
                     for (size_t i = 0; i < scc.size(); i++) {
                         VERBOSE_ONLY(T) {
                             std::string s = scc[i]->getName().str();

--- a/src/tcompilerstate.h
+++ b/src/tcompilerstate.h
@@ -2,10 +2,7 @@
 #define _tcompilerstate_h
 
 #include "llvmheaders.h"
-#if LLVM_VERSION < 170
-// FIXME (Elliott): need to restore the manual inliner in LLVM 17
 #include "tinline.h"
-#endif
 
 struct TerraFunctionInfo {
     llvm::LLVMContext *ctx;
@@ -44,18 +41,14 @@ struct TerraCompilationUnit {
               T(NULL),
               C(NULL),
               M(NULL),
-#if LLVM_VERSION < 170
-              // FIXME (Elliott): need to restore the manual inliner in LLVM 17
               mi(NULL),
-#endif
               fpm(NULL),
               ee(NULL),
               jiteventlistener(NULL),
               Ty(NULL),
               CC(NULL),
               symbols(NULL),
-              functioncount(0) {
-    }
+              functioncount(0) {}
     int nreferences;
     // configuration
     bool optimize;
@@ -66,10 +59,8 @@ struct TerraCompilationUnit {
     terra_CompilerState *C;
     TerraTarget *TT;
     llvm::Module *M;
-#if LLVM_VERSION < 170
-    // FIXME (Elliott): need to restore the manual inliner in LLVM 17
     ManualInliner *mi;
-#else
+#if LLVM_VERSION >= 170
     llvm::LoopAnalysisManager lam;
     llvm::FunctionAnalysisManager fam;
     llvm::CGSCCAnalysisManager cgam;

--- a/src/tinline.cpp
+++ b/src/tinline.cpp
@@ -1,11 +1,7 @@
-#ifdef TERRA_LLVM_HEADERS_HAVE_NDEBUG
-// somewhere in LLVM's header files they define an object differently
-// if NDEBUG is on, causing CallGraph functions to crash.
-// we compile this file with a matching NDEBUG setting to get around this
-#define NDEBUG
-#endif
 #include "llvmheaders.h"
 #include "tinline.h"
+
+#if LLVM_VERSION < 170
 
 using namespace llvm;
 
@@ -67,3 +63,143 @@ void ManualInliner::run(std::vector<Function *>::iterator fbegin,
         CG->getOrInsertFunction(*fp)->removeAllCalledFunctions();
     }
 }
+
+#else  // LLVM_VERSION >= 170
+
+// LLVM 17 removed the legacy pass manager pipeline Terra used to borrow the
+// inliner from: the new inliner is a CGSCC pass that can only be driven through
+// LazyCallGraph and CGSCCUpdateResult, neither of which can be kept up to date
+// while Terra adds functions to the module one at a time. So instead we drive
+// the pieces the inliner is built out of -- getInlineCost, shouldInline and
+// InlineFunction -- directly. This mirrors InlinerPass::run and
+// DefaultInlineAdvisor::getAdviceImpl, minus the call graph bookkeeping.
+
+#include "llvm/ADT/SmallPtrSet.h"
+#include "llvm/ADT/SmallVector.h"
+#include "llvm/Analysis/AssumptionCache.h"
+#include "llvm/Analysis/BlockFrequencyInfo.h"
+#include "llvm/Analysis/InlineAdvisor.h"
+#include "llvm/Analysis/InlineCost.h"
+#include "llvm/Analysis/OptimizationRemarkEmitter.h"
+#include "llvm/Analysis/ProfileSummaryInfo.h"
+#include "llvm/Analysis/TargetLibraryInfo.h"
+#include "llvm/Analysis/TargetTransformInfo.h"
+#include "llvm/IR/ValueHandle.h"
+#include "llvm/Transforms/Utils/Cloning.h"
+
+using namespace llvm;
+
+// Terra's function pipeline is built at -O3, so match the inlining thresholds
+// LLVM would use for a -O3 module pipeline.
+ManualInliner::ManualInliner(TargetMachine *TM, Module *m, FunctionAnalysisManager &fam,
+                             ModuleAnalysisManager &mam)
+        : M(m), FAM(&fam), MAM(&mam), Params(getInlineParams(3, 0)) {}
+
+// Return true if the given inline history includes F. A call site inherits the
+// history of the call that exposed it, so this is what stops us from inlining a
+// recursive cycle forever.
+static bool inlineHistoryIncludes(
+        Function *F, int HistoryID,
+        const SmallVectorImpl<std::pair<Function *, int> > &InlineHistory) {
+    while (HistoryID != -1) {
+        assert(unsigned(HistoryID) < InlineHistory.size() && "invalid inline history ID");
+        if (InlineHistory[HistoryID].first == F) return true;
+        HistoryID = InlineHistory[HistoryID].second;
+    }
+    return false;
+}
+
+static bool isInlineCandidate(CallBase *CB) {
+    if (isa<IntrinsicInst>(CB)) return false;
+    // Indirect calls have nothing to inline. LLVM's inliner additionally tries
+    // tryPromoteCall to devirtualize them first; we don't bother.
+    Function *Callee = CB->getCalledFunction();
+    return Callee && !Callee->isDeclaration();
+}
+
+void ManualInliner::run(std::vector<Function *>::iterator fbegin,
+                        std::vector<Function *>::iterator fend) {
+    SmallPtrSet<Function *, 8> SCCFunctions(fbegin, fend);
+
+    ProfileSummaryInfo *PSI = &MAM->getResult<ProfileSummaryAnalysis>(*M);
+    auto GetAssumptionCache = [&](Function &F) -> AssumptionCache & {
+        return FAM->getResult<AssumptionAnalysis>(F);
+    };
+    auto GetBFI = [&](Function &F) -> BlockFrequencyInfo & {
+        return FAM->getResult<BlockFrequencyAnalysis>(F);
+    };
+    auto GetTLI = [&](Function &F) -> const TargetLibraryInfo & {
+        return FAM->getResult<TargetLibraryAnalysis>(F);
+    };
+    auto GetInlineCost = [&](CallBase &CB) -> InlineCost {
+        Function &Callee = *CB.getCalledFunction();
+        TargetTransformInfo &CalleeTTI = FAM->getResult<TargetIRAnalysis>(Callee);
+        return getInlineCost(CB, Params, CalleeTTI, GetAssumptionCache, GetTLI, GetBFI,
+                             PSI);
+    };
+
+    // Collect the call sites in this SCC up front. Sites exposed by inlining are
+    // appended as we go, tagged with the history of what was inlined to create
+    // them. Weak handles because inlining can delete instructions in the caller.
+    SmallVector<std::pair<WeakTrackingVH, int>, 16> Calls;
+    SmallVector<std::pair<Function *, int>, 8> InlineHistory;
+    for (std::vector<Function *>::iterator fp = fbegin; fp != fend; ++fp)
+        for (BasicBlock &BB : **fp)
+            for (Instruction &I : BB)
+                if (CallBase *CB = dyn_cast<CallBase>(&I))
+                    if (isInlineCandidate(CB)) Calls.push_back({CB, -1});
+    if (Calls.empty()) return;
+
+    // Inline calls that leave the SCC before calls that stay inside it, so that
+    // a recursive function is fully built out before we consider unrolling it
+    // into itself. This is what LLVM's inliner does with its SCC worklist.
+    std::stable_partition(
+            Calls.begin(), Calls.end(), [&](const std::pair<WeakTrackingVH, int> &C) {
+                return !SCCFunctions.count(cast<CallBase>(C.first)->getCalledFunction());
+            });
+
+    InlineFunctionInfo IFI(GetAssumptionCache, PSI);
+    SmallPtrSet<Function *, 8> Inlined;
+
+    for (unsigned i = 0; i < Calls.size(); ++i) {
+        CallBase *CB = dyn_cast_or_null<CallBase>(Calls[i].first);
+        if (!CB || !isInlineCandidate(CB)) continue;
+        int HistoryID = Calls[i].second;
+        Function *Callee = CB->getCalledFunction();
+        Function *Caller = CB->getCaller();
+
+        // Don't chase a cycle we have already been around once.
+        if (HistoryID != -1 && inlineHistoryIncludes(Callee, HistoryID, InlineHistory))
+            continue;
+
+        OptimizationRemarkEmitter &ORE =
+                FAM->getResult<OptimizationRemarkEmitterAnalysis>(*Caller);
+        // shouldInline layers the "would it be better to inline the caller into
+        // its own callers instead" deferral heuristic over the raw cost, and
+        // returns nullopt when we should leave the call alone.
+        if (!shouldInline(*CB,
+#if LLVM_VERSION >= 200
+                          FAM->getResult<TargetIRAnalysis>(*Callee),
+#endif
+                          GetInlineCost, ORE))
+            continue;
+
+        IFI.reset();
+        if (!InlineFunction(*CB, IFI, /*MergeAttributes=*/true).isSuccess()) continue;
+        Inlined.insert(Caller);
+
+        // Anything the callee used to call is now a call site in the caller.
+        if (!IFI.InlinedCallSites.empty()) {
+            int NewHistoryID = InlineHistory.size();
+            InlineHistory.push_back({Callee, HistoryID});
+            for (CallBase *NewCB : IFI.InlinedCallSites)
+                if (isInlineCandidate(NewCB)) Calls.push_back({NewCB, NewHistoryID});
+        }
+    }
+
+    // Cached analyses for anything we changed are stale; the function pipeline
+    // runs on these functions next.
+    for (Function *F : Inlined) FAM->invalidate(*F, PreservedAnalyses::none());
+}
+
+#endif

--- a/src/tinline.h
+++ b/src/tinline.h
@@ -3,16 +3,36 @@
 
 #include "llvmheaders.h"
 
+#if LLVM_VERSION >= 170
+#include "llvm/Analysis/InlineCost.h"
+#endif
+
+// Terra compiles functions one strongly-connected-component at a time, so it
+// cannot use LLVM's module-at-a-time inliner in the JIT. Instead it drives an
+// inliner by hand over each SCC as that SCC is completed (see EmitFunction in
+// tcompiler.cpp). Callees are always emitted and optimized before their
+// callers, so this reproduces the bottom-up order LLVM's own inliner uses.
 class ManualInliner {
+#if LLVM_VERSION < 170
     llvm::CallGraphSCCPass *SI;
     llvm::CallGraph *CG;
     PassManager PM;
 
 public:
     ManualInliner(llvm::TargetMachine *tm, llvm::Module *m);
+    void eraseFunction(llvm::Function *f);
+#else
+    llvm::Module *M;
+    llvm::FunctionAnalysisManager *FAM;
+    llvm::ModuleAnalysisManager *MAM;
+    llvm::InlineParams Params;
+
+public:
+    ManualInliner(llvm::TargetMachine *tm, llvm::Module *m,
+                  llvm::FunctionAnalysisManager &fam, llvm::ModuleAnalysisManager &mam);
+#endif
     void run(std::vector<llvm::Function *>::iterator fbegin,
              std::vector<llvm::Function *>::iterator fend);
-    void eraseFunction(llvm::Function *f);
 };
 
 #endif

--- a/tests/inline_jit_attrs.t
+++ b/tests/inline_jit_attrs.t
@@ -4,16 +4,14 @@
 -- the positive checks fail while these still pass, inlining is genuinely off
 -- rather than the detection being wrong.
 local I = require("inlinelib")
-print("inline_jit_attrs:")
 
 local C = terralib.includec("stdio.h")
 
 -- setinlined(true) puts alwaysinline on the callee.
-local attr_shouty = terra()
+terra attr_shouty()
     C.printf("") C.printf("") C.printf("") C.printf("") C.printf("")
     C.printf("") C.printf("") C.printf("") C.printf("") C.printf("")
 end
-attr_shouty:setname("attr_shouty")
 attr_shouty:setinlined(true)
 terra attr_usesshouty()
     attr_shouty()

--- a/tests/inline_jit_attrs.t
+++ b/tests/inline_jit_attrs.t
@@ -1,0 +1,60 @@
+-- The attributes that steer the JIT inliner: setinlined(true/false) and
+-- setoptimized(false). The two suppression cases are the controls for this
+-- whole family of tests -- they keep passing when the inliner is broken, so if
+-- the positive checks fail while these still pass, inlining is genuinely off
+-- rather than the detection being wrong.
+local I = require("inlinelib")
+print("inline_jit_attrs:")
+
+local C = terralib.includec("stdio.h")
+
+-- setinlined(true) puts alwaysinline on the callee.
+local attr_shouty = terra()
+    C.printf("") C.printf("") C.printf("") C.printf("") C.printf("")
+    C.printf("") C.printf("") C.printf("") C.printf("") C.printf("")
+end
+attr_shouty:setname("attr_shouty")
+attr_shouty:setinlined(true)
+terra attr_usesshouty()
+    attr_shouty()
+    attr_shouty()
+    return 4
+end
+assert(attr_usesshouty() == 4)
+I.assertinlined("setinlined(true) callee", I.body(attr_usesshouty), {attr_shouty})
+
+-- setinlined(false) puts noinline on the callee: it must survive as a call even
+-- though it is small enough that the cost model would otherwise take it.
+terra attr_noinline(x : int) return x + 1 end
+attr_noinline:setinlined(false)
+terra attr_usesnoinline(x : int) return attr_noinline(x) end
+assert(attr_usesnoinline(10) == 11)
+I.assertnotinlined("setinlined(false) callee", I.body(attr_usesnoinline),
+                   {attr_noinline})
+
+-- setoptimized(false) puts optnone on the *caller*, so nothing may be inlined
+-- into it.
+terra attr_plain(x : int) return x + 1 end
+terra attr_optnone(x : int) return attr_plain(x) end
+attr_optnone:setoptimized(false)
+assert(attr_optnone(10) == 11)
+I.assertnotinlined("setoptimized(false) caller", I.body(attr_optnone), {attr_plain})
+
+-- setoptimized(false) also implies noinline, so such a function is not inlined
+-- into its own callers either.
+terra attr_optnone2(x : int) return x + 1 end
+attr_optnone2:setoptimized(false)
+terra attr_callsoptnone(x : int) return attr_optnone2(x) + 1 end
+assert(attr_callsoptnone(10) == 12)
+I.assertnotinlined("optnone function as a callee", I.body(attr_callsoptnone),
+                   {attr_optnone2})
+
+-- Mixing the two in one caller: the plain callee goes, the noinline one stays.
+terra attr_small(x : int) return x * 2 end
+terra attr_blocked(x : int) return x * 3 end
+attr_blocked:setinlined(false)
+terra attr_mixed(x : int) return attr_small(x) + attr_blocked(x) end
+assert(attr_mixed(4) == 20)
+local mixed = I.body(attr_mixed)
+I.assertinlined("mixed caller, inlinable callee", mixed, {attr_small})
+I.assertnotinlined("mixed caller, noinline callee", mixed, {attr_blocked})

--- a/tests/inline_jit_recursive.t
+++ b/tests/inline_jit_recursive.t
@@ -10,7 +10,6 @@
 -- These do declare return types, because inference does not always terminate
 -- through a recursive cycle.
 local I = require("inlinelib")
-print("inline_jit_recursive:")
 
 terra rec_helper(x : int) return x + 1 end
 

--- a/tests/inline_jit_recursive.t
+++ b/tests/inline_jit_recursive.t
@@ -1,0 +1,86 @@
+-- SCCs that contain cycles. Without a call graph to lean on, the JIT inliner
+-- bounds itself with an inline-history chain, so mutually recursive groups are
+-- the case most likely to loop forever or blow up.
+--
+-- Recursive calls themselves are deliberately not asserted on: whether LLVM
+-- unrolls one level of a cycle is a cost-model detail that varies by version.
+-- What is asserted is that a cyclic SCC still gets its *non-recursive* callees
+-- inlined, which is the part that would break if the inliner bailed on cycles.
+--
+-- These do declare return types, because inference does not always terminate
+-- through a recursive cycle.
+local I = require("inlinelib")
+print("inline_jit_recursive:")
+
+terra rec_helper(x : int) return x + 1 end
+
+-- One SCC of one function, with a self-edge.
+terra rec_fact(n : int) : int
+    if n <= 1 then
+        return rec_helper(0)
+    end
+    return n * rec_fact(n - 1)
+end
+assert(rec_fact(5) == 120)
+I.assertinlined("1-function SCC (self-recursive)", I.body(rec_fact), {rec_helper})
+
+-- One SCC of two functions.
+local terra rec_odd :: {int} -> int
+terra rec_even(n : int) : int
+    if n == 0 then
+        return rec_helper(0)
+    end
+    return rec_odd(n - 1)
+end
+terra rec_odd(n : int) : int
+    if n == 0 then
+        return rec_helper(-1)
+    end
+    return rec_even(n - 1)
+end
+assert(rec_even(10) == 1 and rec_even(7) == 0 and rec_odd(7) == 1)
+I.assertinlined("2-function SCC", I.body(rec_even), {rec_helper})
+I.assertinlined("2-function SCC (other member)", I.body(rec_odd), {rec_helper})
+
+-- One SCC of three functions.
+local terra rec3_b :: {int} -> int
+local terra rec3_c :: {int} -> int
+terra rec3_a(n : int) : int
+    if n <= 0 then
+        return rec_helper(0)
+    end
+    return rec3_b(n - 1) + rec_helper(1)
+end
+terra rec3_b(n : int) : int
+    if n <= 0 then
+        return rec_helper(0)
+    end
+    return rec3_c(n - 1) + rec_helper(1)
+end
+terra rec3_c(n : int) : int
+    if n <= 0 then
+        return rec_helper(0)
+    end
+    return rec3_a(n - 1) + rec_helper(1)
+end
+assert(rec3_a(6) == 13)
+I.assertinlined("3-function SCC", I.body(rec3_a), {rec_helper})
+
+-- alwaysinline on a recursive function: the attribute cannot be honoured all
+-- the way down, so this checks the inliner stops rather than obeying forever.
+terra rec_ai(n : int) : int
+    if n <= 0 then
+        return 0
+    end
+    return 1 + rec_ai(n - 1)
+end
+rec_ai:setinlined(true)
+terra rec_usesai() return rec_ai(4) end
+assert(rec_usesai() == 4)
+print("  alwaysinline recursion terminated")
+
+-- A cycle reached only through a non-recursive entry point, so the entry point
+-- is its own SCC and the cycle is another.
+terra rec_entry(n : int) return rec_even(n) + rec_helper(0) end
+assert(rec_entry(4) == 2)
+I.assertinlined("SCC calling a cyclic SCC", I.body(rec_entry), {rec_helper})

--- a/tests/inline_jit_scc.t
+++ b/tests/inline_jit_scc.t
@@ -2,7 +2,6 @@
 -- component, so vary how many SCCs there are and how they are connected.
 -- See tests/inlinelib.lua for how inlining is detected.
 local I = require("inlinelib")
-print("inline_jit_scc:")
 
 -- Two SCCs: one callee, one caller, one call site. The simplest thing that can
 -- possibly work.

--- a/tests/inline_jit_scc.t
+++ b/tests/inline_jit_scc.t
@@ -1,0 +1,62 @@
+-- Call graph shapes: the JIT inliner is driven once per strongly connected
+-- component, so vary how many SCCs there are and how they are connected.
+-- See tests/inlinelib.lua for how inlining is detected.
+local I = require("inlinelib")
+print("inline_jit_scc:")
+
+-- Two SCCs: one callee, one caller, one call site. The simplest thing that can
+-- possibly work.
+terra scc_add3(a : int, b : int, c : int) return a + b + c end
+terra scc_one(x : int) return scc_add3(x, 1, 2) end
+assert(scc_one(10) == 13)
+I.assertinlined("2 SCCs, 1 call site", I.body(scc_one), {scc_add3})
+
+-- Two SCCs, but the callee is used from several sites in the same caller. This
+-- inlines repeatedly into one function, which is where stale cached analyses
+-- would show up.
+terra scc_multi(x : int)
+    return scc_add3(x, 1, 2) + scc_add3(x, 3, 4) + scc_add3(x, 5, 6)
+end
+assert(scc_multi(10) == 51)
+I.assertinlined("2 SCCs, 3 call sites", I.body(scc_multi), {scc_add3})
+
+-- Four SCCs in a chain. Only the innermost call is visible when the outermost
+-- function is emitted; the rest are exposed by inlining, so this exercises the
+-- worklist and the inline history that bounds it.
+terra scc_l1(x : int) return x + 1 end
+terra scc_l2(x : int) return scc_l1(x) * 2 end
+terra scc_l3(x : int) return scc_l2(x) + 3 end
+terra scc_l4(x : int) return scc_l3(x) * 5 end
+assert(scc_l4(10) == 125)
+I.assertinlined("4 SCCs, chain", I.body(scc_l4), {scc_l1, scc_l2, scc_l3})
+
+-- Four SCCs in a diamond: two independent callers of a shared leaf, joined.
+terra scc_leaf(x : int) return x * 3 end
+terra scc_left(x : int) return scc_leaf(x) + 1 end
+terra scc_right(x : int) return scc_leaf(x) - 1 end
+terra scc_top(x : int) return scc_left(x) + scc_right(x) end
+assert(scc_top(10) == 60)
+I.assertinlined("4 SCCs, diamond", I.body(scc_top), {scc_leaf, scc_left, scc_right})
+
+-- A callee with control flow, so inlining has to split the caller's block
+-- rather than splice a single basic block in.
+terra scc_branchy(x : int)
+    if x < 0 then
+        return -x
+    elseif x == 0 then
+        return 100
+    else
+        return x * 2
+    end
+end
+terra scc_usesbranchy(x : int) return scc_branchy(x) + scc_branchy(-x) end
+assert(scc_usesbranchy(5) == 15 and scc_usesbranchy(0) == 200)
+I.assertinlined("2 SCCs, multi-block callee", I.body(scc_usesbranchy), {scc_branchy})
+
+-- An indirect call has no known callee. It must be left alone rather than
+-- crash the inliner, and the code still has to work.
+terra scc_indirect(f : {int} -> int, x : int) return f(x) + f(x) end
+terra scc_callsindirect(x : int) return scc_indirect(scc_leaf, x) end
+assert(scc_callsindirect(4) == 24)
+I.body(scc_indirect) -- the inliner saw an unresolvable callee and survived
+print("  indirect call survived")

--- a/tests/inline_jit_types.t
+++ b/tests/inline_jit_types.t
@@ -63,10 +63,20 @@ end
 assert(ty_usedivmod(17, 5) == 302)
 I.assertinlined("multiple return values", I.body(ty_usedivmod), {ty_divmod})
 
--- A C function inlined into Terra through the JIT.
+-- A C callee going through the JIT inliner.
+--
+-- Whether the C function is actually inlined is deliberately not asserted.
+-- Clang's choice of linkage for a C `inline` definition varies by target and by
+-- clang version, and an interposable definition (weak, linkonce) may not be
+-- inlined at all -- so the outcome differs across the platforms Terra supports.
+-- This is not specific to the manual inliner: LLVM 12, which still drives the
+-- legacy inliner, declines to inline it just the same. What is checked here is
+-- that a cross-language callee compiles and runs correctly through the
+-- inliner; inline_c.t covers C inlining end to end via saveobj.
 local Cinl = terralib.includecstring[[
 inline int ty_cadd(int a, int b) { return a + b; }
 ]]
 terra ty_usec(x : int) return Cinl.ty_cadd(x, 5) end
 assert(ty_usec(3) == 8)
-I.assertinlined("C inline function into Terra", I.body(ty_usec), {"ty_cadd"})
+I.body(ty_usec)
+print(string.format("  %-44s %s", "C callee (inlining is not portable)", "ok"))

--- a/tests/inline_jit_types.t
+++ b/tests/inline_jit_types.t
@@ -1,0 +1,72 @@
+-- Inlining across the argument and return shapes Terra's C calling convention
+-- handles specially: aggregates passed in registers, aggregates passed in
+-- memory (byval/sret), arrays, pointers, and unit returns. These take different
+-- paths through CCallingConv, so an inliner bug can easily show up in one and
+-- not the others. Also covers inlining a C function into Terra in the JIT --
+-- inline_c.t covers the same thing for saveobj, which uses a different pipeline.
+local I = require("inlinelib")
+print("inline_jit_types:")
+
+-- Small struct: returned in registers on most targets.
+struct TySmall { a : int, b : int }
+terra ty_mksmall(a : int, b : int) return TySmall { a, b } end
+terra ty_sumsmall(a : int, b : int)
+    var s = ty_mksmall(a, b)
+    return s.a + s.b
+end
+assert(ty_sumsmall(3, 4) == 7)
+I.assertinlined("small struct by value", I.body(ty_sumsmall), {ty_mksmall})
+
+-- Large struct: goes through memory, i.e. byval/sret.
+struct TyBig { a : int, b : int, c : int, d : int, e : int, f : int, g : int, h : int }
+terra ty_mkbig(seed : int)
+    return TyBig { seed, seed+1, seed+2, seed+3, seed+4, seed+5, seed+6, seed+7 }
+end
+terra ty_takebig(v : TyBig) return v.a + v.d + v.h end
+terra ty_usebig(seed : int) return ty_takebig(ty_mkbig(seed)) end
+assert(ty_usebig(1) == 1 + 4 + 8)
+I.assertinlined("large struct (byval/sret)", I.body(ty_usebig),
+                {ty_mkbig, ty_takebig})
+
+-- Array-typed values.
+terra ty_mkarr(x : int)
+    var a : int[4]
+    a[0], a[1], a[2], a[3] = x, x+1, x+2, x+3
+    return a
+end
+terra ty_usearr(x : int)
+    var a = ty_mkarr(x)
+    return a[0] + a[3]
+end
+assert(ty_usearr(10) == 23)
+I.assertinlined("array by value", I.body(ty_usearr), {ty_mkarr})
+
+-- Pointer arguments, i.e. mutation through the callee, and a unit return.
+terra ty_bump(p : &int, by : int)
+    @p = @p + by
+end
+terra ty_usebump(x : int)
+    var v = x
+    ty_bump(&v, 5)
+    ty_bump(&v, 7)
+    return v
+end
+assert(ty_usebump(1) == 13)
+I.assertinlined("pointer arg, unit return", I.body(ty_usebump), {ty_bump})
+
+-- Multiple return values.
+terra ty_divmod(a : int, b : int) return a / b, a % b end
+terra ty_usedivmod(a : int, b : int)
+    var q, r = ty_divmod(a, b)
+    return q * 100 + r
+end
+assert(ty_usedivmod(17, 5) == 302)
+I.assertinlined("multiple return values", I.body(ty_usedivmod), {ty_divmod})
+
+-- A C function inlined into Terra through the JIT.
+local Cinl = terralib.includecstring[[
+inline int ty_cadd(int a, int b) { return a + b; }
+]]
+terra ty_usec(x : int) return Cinl.ty_cadd(x, 5) end
+assert(ty_usec(3) == 8)
+I.assertinlined("C inline function into Terra", I.body(ty_usec), {"ty_cadd"})

--- a/tests/inline_jit_types.t
+++ b/tests/inline_jit_types.t
@@ -5,7 +5,6 @@
 -- not the others. Also covers inlining a C function into Terra in the JIT --
 -- inline_c.t covers the same thing for saveobj, which uses a different pipeline.
 local I = require("inlinelib")
-print("inline_jit_types:")
 
 -- Small struct: returned in registers on most targets.
 struct TySmall { a : int, b : int }

--- a/tests/inlinelib.lua
+++ b/tests/inlinelib.lua
@@ -21,18 +21,10 @@
 
 local M = {}
 
-local DUMP = "._inline_jit_ir.ll"
-
 local function jitir()
-    -- optimize=false matters: with optimization on, saveobj would run the whole
-    -- module pipeline, whose own inliner would inline everything regardless of
-    -- what the JIT did, masking exactly what we are trying to observe.
-    terralib.jitcompilationunit:saveobj(DUMP, "llvmir", {}, false)
-    local h = assert(io.open(DUMP, "r"), "could not open " .. DUMP)
-    local ir = h:read("*a")
-    h:close()
-    os.remove(DUMP)
-    return ir
+    -- Keep optimizations disabled so that we don't accidentally run the module-level inliner.
+    return assert(terralib.jitcompilationunit:saveobj(nil, "llvmir", {}, false --[[ optimize ]]),
+                  "no LLVM IR returned for the JIT compilation unit")
 end
 
 local function nameof(fn)

--- a/tests/inlinelib.lua
+++ b/tests/inlinelib.lua
@@ -1,0 +1,122 @@
+-- Helpers for the JIT inliner tests (inline_jit_*.t).
+--
+-- Terra's JIT compiles one strongly connected component of the call graph at a
+-- time, and inlines into an SCC as that SCC completes (ManualInliner, see
+-- src/tinline.cpp). Because that path is separate from the module-at-a-time
+-- pipeline used by saveobj, it can regress on its own -- it did, silently, from
+-- LLVM 17 until the manual inliner was ported to the new pass manager. These
+-- helpers let a test detect that automatically instead of eyeballing a
+-- disassembly.
+--
+-- Two deliberate choices keep the checks portable:
+--
+--   * they read textual LLVM IR, not machine code, so they do not depend on the
+--     target architecture; and
+--   * they match on callee symbol names, not on instruction counts or opcodes,
+--     so they do not depend on the LLVM version's choice of instructions,
+--     attributes, or output formatting.
+--
+-- Callees are named by passing the Terra function object itself, so a test can
+-- never drift out of sync with the symbol it is really asserting on.
+
+local M = {}
+
+local DUMP = "._inline_jit_ir.ll"
+
+local function jitir()
+    -- optimize=false matters: with optimization on, saveobj would run the whole
+    -- module pipeline, whose own inliner would inline everything regardless of
+    -- what the JIT did, masking exactly what we are trying to observe.
+    terralib.jitcompilationunit:saveobj(DUMP, "llvmir", {}, false)
+    local h = assert(io.open(DUMP, "r"), "could not open " .. DUMP)
+    local ir = h:read("*a")
+    h:close()
+    os.remove(DUMP)
+    return ir
+end
+
+local function nameof(fn)
+    if type(fn) == "string" then return fn end
+    return assert(fn.name, "expected a Terra function or a symbol name")
+end
+
+local function escape(s) return (s:gsub("[%^%$%(%)%%%.%[%]%*%+%-%?]", "%%%0")) end
+
+-- Terra emits its own functions as @"$name", doubling the $ for a few names
+-- that would otherwise collide with clang's (TerraSymbolPrefix in
+-- src/tcompiler.cpp). Functions imported from C keep their own name unprefixed.
+local function candidates(fn)
+    local n = nameof(fn)
+    return { "$" .. n, "$$" .. n, n }
+end
+
+-- True if body still mentions the callee's symbol, i.e. it was not inlined.
+local function refers(body, fn)
+    for _, sym in ipairs(candidates(fn)) do
+        if body:find('@"' .. sym .. '"', 1, true) then return true end
+        -- Unquoted form: check the match is the whole symbol and not a prefix
+        -- of a longer one.
+        local i = 1
+        while true do
+            local s, e = body:find("@" .. sym, i, true)
+            if not s then break end
+            if not body:sub(e + 1, e + 1):match("[%w_%.%$]") then return true end
+            i = e + 1
+        end
+    end
+    return false
+end
+
+-- Compile fn and return the text of its LLVM definition from the JIT module.
+function M.body(fn)
+    fn:compile()
+    local ir = jitir()
+    for _, sym in ipairs(candidates(fn)) do
+        local body = ir:match('\ndefine[^\n]-@"' .. escape(sym) .. '"%(.-\n}')
+                  or ir:match('\ndefine[^\n]-@' .. escape(sym) .. '%(.-\n}')
+        if body then return body end
+    end
+    error("no LLVM definition for '" .. nameof(fn) .. "' in the JIT module", 2)
+end
+
+local function describe(callees)
+    local names = {}
+    for i, c in ipairs(callees) do names[i] = nameof(c) end
+    return table.concat(names, " ")
+end
+
+local function report(case, verdict, callees)
+    print(string.format("  %-44s %s %s", case, verdict, describe(callees)))
+end
+
+local function fail(case, body, msg)
+    error(string.format("%s: %s\n--- LLVM IR ---\n%s\n---------------", case, msg, body),
+          3)
+end
+
+-- Assert every callee was inlined into body, i.e. body no longer refers to it.
+function M.assertinlined(case, body, callees)
+    for _, callee in ipairs(callees) do
+        if refers(body, callee) then
+            fail(case, body, "expected '" .. nameof(callee) .. "' to be inlined, but "
+                             .. "the caller still refers to it")
+        end
+    end
+    report(case, "inlined ", callees)
+end
+
+-- Assert every callee is still called, i.e. inlining was correctly suppressed.
+-- These are the controls for this family of tests: they keep passing when the
+-- inliner is broken, so if they pass while the positive checks fail, inlining
+-- really is off rather than the detection being wrong.
+function M.assertnotinlined(case, body, callees)
+    for _, callee in ipairs(callees) do
+        if not refers(body, callee) then
+            fail(case, body, "expected '" .. nameof(callee) .. "' NOT to be inlined, "
+                             .. "but the caller no longer refers to it")
+        end
+    end
+    report(case, "kept    ", callees)
+end
+
+return M

--- a/tests/inlinelib.lua
+++ b/tests/inlinelib.lua
@@ -35,7 +35,7 @@ end
 local function escape(s) return (s:gsub("[%^%$%(%)%%%.%[%]%*%+%-%?]", "%%%0")) end
 
 -- Terra emits its own functions as @"$name", doubling the $ for a few names
--- that would otherwise collide with clang's (TerraSymbolPrefix in
+-- that would otherwise collide with ELF's ARM ABI (TerraSymbolPrefix in
 -- src/tcompiler.cpp). Functions imported from C keep their own name unprefixed.
 local function candidates(fn)
     local n = nameof(fn)


### PR DESCRIPTION
LLVM 17 ripped out the old optimization pass infrastructure, and that meant that our manual inliner got left behind. This didn't matter for `terralib.saveobj` because we ran the entire module optimization pipeline, which includes an inlining pass. But it meant that JIT mode effectively saw no inlining performed. This resulted in bugs like: https://github.com/terralang/terra/issues/671

This PR builds a new manual inlining infrastructure for LLVM 17+ based on the pieces that are exposed for us to use. Because doing so at the call graph level is impractical in LLVM, we still maintain the overall approach but build it with pieces that are available in the newer LLVM APIs.

To avoid breaking things in the future, this also adds a set of test cases to ensure the JIT-time inliner is actually working.