### PR TITLE
Restore CUDA optimization for LLVM 17+

### DIFF
--- a/src/tcuda.cpp
+++ b/src/tcuda.cpp
@@ -189,7 +189,11 @@ void moduleToPTX(terra_State *T, llvm::Module *M, int major, int minor, std::str
 #if LLVM_VERSION < 170
     PMB.populateModulePassManager(PM);
 #else
+    // The new pass manager cannot be mixed into the legacy PassManager that
+    // addPassesToEmitFile populates, so optimize the module here, up front,
+    // rather than scheduling the passes alongside code generation.
     M->setDataLayout(TargetMachine->createDataLayout());
+    llvmutil_optimizedevicemodule(M, TargetMachine);
 #endif
 
     if (TargetMachine->addPassesToEmitFile(PM, str_dest, nullptr, FileType)) {

--- a/src/tllvmutil.cpp
+++ b/src/tllvmutil.cpp
@@ -293,6 +293,37 @@ FunctionPassManager llvmutil_createoptimizationpasses(TargetMachine *TM,
 
     return FPM;
 }
+
+// Optimize a device module (currently NVPTX) before handing it to the code
+// generator. This is the same -O3 module pipeline llvmutil_optimizemodule runs
+// for the host, with two differences:
+//
+//   * the vectorizers stay off -- NVPTX is a SIMT target, so loop and SLP
+//     vectorization have nothing to gain there; and
+//   * there is no up-front verify-and-GlobalDCE. That pair exists on the host
+//     path to prune everything outside the export table before optimizing; here
+//     the kernels are already the module's only external symbols, and the O3
+//     pipeline runs GlobalDCE on its own.
+void llvmutil_optimizedevicemodule(Module *M, TargetMachine *TM) {
+    LoopAnalysisManager LAM;
+    FunctionAnalysisManager FAM;
+    CGSCCAnalysisManager CGAM;
+    ModuleAnalysisManager MAM;
+
+    PipelineTuningOptions PTO;
+    PTO.LoopVectorization = false;
+    PTO.SLPVectorization = false;
+    PassBuilder PB(TM, PTO);
+
+    PB.registerModuleAnalyses(MAM);
+    PB.registerCGSCCAnalyses(CGAM);
+    PB.registerFunctionAnalyses(FAM);
+    PB.registerLoopAnalyses(LAM);
+    PB.crossRegisterProxies(LAM, FAM, CGAM, MAM);
+
+    ModulePassManager MPM = PB.buildPerModuleDefaultPipeline(OptimizationLevel::O3);
+    MPM.run(*M, MAM);
+}
 #endif
 
 void llvmutil_disassemblefunction(void *data, size_t numBytes, size_t numInst) {

--- a/src/tllvmutil.h
+++ b/src/tllvmutil.h
@@ -12,6 +12,7 @@ llvm::FunctionPassManager llvmutil_createoptimizationpasses(
         llvm::TargetMachine *TM, llvm::LoopAnalysisManager &LAM,
         llvm::FunctionAnalysisManager &FAM, llvm::CGSCCAnalysisManager &CGAM,
         llvm::ModuleAnalysisManager &MAM);
+void llvmutil_optimizedevicemodule(llvm::Module *M, llvm::TargetMachine *TM);
 #endif
 extern "C" void llvmutil_disassemblefunction(void *data, size_t sz, size_t inst);
 bool llvmutil_emitobjfile(llvm::Module *Mod, llvm::TargetMachine *TM,

--- a/tests/cudaopt.t
+++ b/tests/cudaopt.t
@@ -20,7 +20,6 @@ if not terralib.cudacompile then
     print("CUDA not enabled, not performing test...")
     return
 end
-print("cudaopt:")
 
 -- PTX generation never queries the device, so the target is fixed rather than
 -- taken from the local GPU. Compute capability 7.5 (Turing) is the oldest

--- a/tests/cudaopt.t
+++ b/tests/cudaopt.t
@@ -21,11 +21,10 @@ if not terralib.cudacompile then
     return
 end
 
--- PTX generation never queries the device, so the target is fixed rather than
--- taken from the local GPU. Compute capability 7.5 (Turing) is the oldest
--- architecture CUDA 13 still supports -- it dropped Maxwell, Pascal and Volta
--- -- and LLVM has accepted sm_75 since LLVM 8, so it is valid across the whole
--- range of LLVM and CUDA versions Terra supports.
+-- We can generate PTX without querying the device, so the target is fixed
+-- rather than taken from the local GPU. The exact choice doesn't make much
+-- difference. We choose compute capability 7.5 (Turing) because it's the
+-- oldest architecture CUDA 13 still supports.
 local ARCH = 75
 
 local tid = cudalib.nvvm_read_ptx_sreg_tid_x

--- a/tests/cudaopt.t
+++ b/tests/cudaopt.t
@@ -1,0 +1,108 @@
+-- Device-side (PTX) optimization.
+--
+-- The PTX pipeline in moduleToPTX is separate from both the host JIT and
+-- saveobj, so it can lose its optimizations without any host-side test
+-- noticing. That is exactly what happened from LLVM 17: the port to the new
+-- pass manager dropped the module passes and left only code generation, so
+-- device code stopped being optimized at all for several releases.
+--
+-- Unlike the other cuda*.t tests, this one needs the CUDA toolkit (libnvvm and
+-- libdevice) but *not* a GPU or the driver -- generating PTX never opens
+-- libcuda -- so it deliberately does not skip in CI, which is where a
+-- regression like this should get caught.
+--
+-- Portability: every assertion is about a whole class of PTX construct (is
+-- there a call left to this function, is there a branch at all) rather than an
+-- exact instruction sequence, so none of it depends on the LLVM version, the
+-- CUDA version, the host OS, or the host architecture.
+
+if not terralib.cudacompile then
+    print("CUDA not enabled, not performing test...")
+    return
+end
+print("cudaopt:")
+
+-- PTX generation never queries the device, so the target is fixed rather than
+-- taken from the local GPU. Compute capability 7.5 (Turing) is the oldest
+-- architecture CUDA 13 still supports -- it dropped Maxwell, Pascal and Volta
+-- -- and LLVM has accepted sm_75 since LLVM 8, so it is valid across the whole
+-- range of LLVM and CUDA versions Terra supports.
+local ARCH = 75
+
+local tid = cudalib.nvvm_read_ptx_sreg_tid_x
+
+local function ptxfor(name, kernel)
+    local ptx = cudalib.toptx({ [name] = kernel }, nil, ARCH)
+    assert(ptx and #ptx > 0, "no PTX generated for " .. name)
+    return ptx
+end
+
+local function fail(label, msg, ptx)
+    error(label .. ": " .. msg .. "\n--- PTX ---\n" .. ptx .. "\n-----------", 3)
+end
+
+-- A device function that survived inlining shows up in the PTX both as a .func
+-- definition and as the target of a call, so its name being absent entirely is
+-- the check.
+local function assertinlined(label, ptx, callee)
+    if ptx:find(callee, 1, true) then
+        fail(label, "expected '" .. callee .. "' to be inlined into the kernel", ptx)
+    end
+    print(string.format("  %-46s inlined    %s", label, callee))
+end
+
+-- With the scalar pipeline running, a constant-trip-count loop is fully
+-- unrolled and folded, leaving straight-line code. Without it the loop survives
+-- as a branch: code generation alone cannot unroll.
+local function assertstraightline(label, ptx)
+    if ptx:match("%f[%w]bra%f[%W]") then
+        fail(label, "expected the loop to be optimized away, but the PTX branches", ptx)
+    end
+    print(string.format("  %-46s straight-line (loop unrolled)", label))
+end
+
+-- A device helper is inlined into the kernel that calls it.
+local terra opt_scale(x : float)
+    return x * 3.0f + 1.0f
+end
+terra opt_kern_inline(out : &float)
+    out[tid()] = opt_scale([float](tid()))
+end
+assertinlined("device helper", ptxfor("opt_kern_inline", opt_kern_inline), "opt_scale")
+
+-- Two levels deep: the inner call only becomes visible once the outer one has
+-- been inlined.
+local terra opt_inner(x : float)
+    return x + 1.0f
+end
+local terra opt_outer(x : float)
+    return opt_inner(x) * 2.0f
+end
+terra opt_kern_chain(out : &float)
+    out[tid()] = opt_outer([float](tid()))
+end
+local chain = ptxfor("opt_kern_chain", opt_kern_chain)
+assertinlined("transitive helper (outer)", chain, "opt_outer")
+assertinlined("transitive helper (inner)", chain, "opt_inner")
+
+-- setinlined(true) has to be honoured on the device path too: cudalib.toptx
+-- marks every kernel it wraps that way.
+local terra opt_always(x : float)
+    return x * x + x
+end
+opt_always:setinlined(true)
+terra opt_kern_always(out : &float)
+    out[tid()] = opt_always([float](tid()))
+end
+assertinlined("setinlined(true) helper",
+              ptxfor("opt_kern_always", opt_kern_always), "opt_always")
+
+-- The scalar optimization pipeline runs, not just the inliner.
+terra opt_kern_loop(out : &float)
+    var acc = 0.f
+    for i = 0, 4 do
+        acc = acc + [float](i) * 2.0f
+    end
+    out[tid()] = acc
+end
+assertstraightline("constant-trip loop", ptxfor("opt_kern_loop", opt_kern_loop))


### PR DESCRIPTION
We accidentally lost all optimizations in CUDA code in the upgrade to LLVM 17 by skipping the optimization pipeline. Thus CUDA code was effectively `-O0`. This would appear to explain the note about performance regressions in CUDA from https://github.com/terralang/terra/issues/655.

Add the optimization passes back, along with a test to ensure we at least have some sorts of optimizations running on the generated CUDA code (e.g., we can check that inlining works by verifying that the inlined target no longer appears in the optimized code).