### PR TITLE
Fix tests using APIs removed in CUDA 13

### DIFF
--- a/tests/cudaatomic.t
+++ b/tests/cudaatomic.t
@@ -21,7 +21,7 @@ local C = terralib.includecstring [[
 #include <stdio.h>
 ]]
 
-sync = terralib.externfunction("cudaThreadSynchronize", {} -> int)
+sync = terralib.externfunction("cudaDeviceSynchronize", {} -> int)
 
 local R = terralib.cudacompile({ bar = foo },true)
 

--- a/tests/cudahello.t
+++ b/tests/cudahello.t
@@ -18,7 +18,7 @@ foo = terra(result : &float)
 end
 
 
-sync = terralib.externfunction("cudaThreadSynchronize", {} -> int)
+sync = terralib.externfunction("cudaDeviceSynchronize", {} -> int)
 
 local R = terralib.cudacompile({ bar = foo })
 

--- a/tests/cudatex.t
+++ b/tests/cudatex.t
@@ -27,7 +27,7 @@ foo = terra(result : C.cudaTextureObject_t)
     vprintf("%f\n",[&int8](&rr))    
 end
 
-sync = terralib.externfunction("cudaThreadSynchronize", {} -> int)
+sync = terralib.externfunction("cudaDeviceSynchronize", {} -> int)
 
 local R = terralib.cudacompile({ foo = foo })
 

--- a/tests/disabled/cudaldg.t
+++ b/tests/disabled/cudaldg.t
@@ -24,7 +24,7 @@ end
 
 terralib.includepath = terralib.includepath..";/usr/local/cuda/include"
 
-sync = terralib.externfunction("cudaThreadSynchronize", {} -> int)
+sync = terralib.externfunction("cudaDeviceSynchronize", {} -> int)
 
 local R = terralib.cudacompile({ foo = foo })
 


### PR DESCRIPTION
CUDA 13 removes `cudaThreadSynchronize`, so replace it with `cudaDeviceSynchronize`.