### PR TITLE
Update LuaJIT to 2026-07-18 commit

### DIFF
--- a/cmake/Modules/GetLuaJIT.cmake
+++ b/cmake/Modules/GetLuaJIT.cmake
@@ -14,10 +14,14 @@ if(TERRA_LUA STREQUAL "luajit")
   set(LUAJIT_BASE "luajit")
   set(LUAJIT_VERSION_MAJOR 2)
   set(LUAJIT_VERSION_MINOR 1)
-  set(LUAJIT_VERSION_PATCH 1720049189)
+  set(LUAJIT_VERSION_PATCH 1784360928)
   set(LUAJIT_VERSION_EXTRA "")
-  set(LUAJIT_COMMIT "04dca7911ea255f37be799c18d74c305b921c1a6") # 2024-08-07
-  set(LUAJIT_HASH_SHA256 "346b028d9ba85e04b7e23a43cc51ec076574d2efc0d271d4355141b0145cd6e0")
+  # This is the commit immediately prior to
+  # a2ce8114f107464473070427e69e84f4923bd08a which backports LuaJIT 3.0 syntax
+  # into v2.1. Bumping this commit any futher may require changes to Terra to
+  # keep up with the LuaJIT language changes.
+  set(LUAJIT_COMMIT "14d8a7a27dc8c626ab9e7c7e9e50b6df6def4f03") # 2026-07-18
+  set(LUAJIT_HASH_SHA256 "daf57ed14e863e70ca202909a4ec4c2fda8e271e6c9dd00c502242ebc4ccbe79")
   if(NOT LUAJIT_VERSION_COMMIT STREQUAL "")
     set(LUAJIT_URL_PREFIX "https://github.com/LuaJIT/LuaJIT/archive/")
   else()

--- a/default.nix
+++ b/default.nix
@@ -6,7 +6,7 @@
 
 let
 
-  llvmPackages = pkgs.llvmPackages_13;
+  llvmPackages = pkgs.llvmPackages_16;
   stdenv = llvmPackages.stdenv;
   cuda = if cudaPackages ? cudatoolkit_12 then [
            cudaPackages.cudatoolkit_12
@@ -15,14 +15,14 @@ let
            cudaPackages.cuda_cudart
          ];
 
-  luajitRev = "04dca7911ea255f37be799c18d74c305b921c1a6";
+  luajitRev = "14d8a7a27dc8c626ab9e7c7e9e50b6df6def4f03";
   luajitBase = "LuaJIT-${luajitRev}";
   luajitArchive = "${luajitBase}.tar.gz";
   luajitSrc = fetchFromGitHub {
     owner = "LuaJIT";
     repo = "LuaJIT";
     rev = luajitRev;
-    sha256 = "0694z8rmqskx86a375ag7qp2wbdri986l5qdz0zalllp4b1hxy92";
+    sha256 = "0faij1v5qq7jd4h0np6dnbxfdjd707bjrwmasy32zj43530gsrvk";
   };
   llvmMerged = symlinkJoin {
     name = "llvmClangMerged";
@@ -92,8 +92,7 @@ in stdenv.mkDerivation rec {
   meta = with lib; {
     description = "A low-level counterpart to Lua";
     homepage = "http://terralang.org/";
-    # Note: Nix has removed LLVM 11, required for Linux AArch64
-    platforms = platforms.x86_64 ++ platforms.darwin; # ++ platforms.aarch64;
+    platforms = platforms.all;
     maintainers = with maintainers; [ jb55 thoughtpolice ];
     license = licenses.mit;
   };

--- a/default.nix
+++ b/default.nix
@@ -58,7 +58,7 @@ in stdenv.mkDerivation rec {
     "-DTERRA_VERSION=${version}"
     "-DTERRA_LUA=luajit"
     "-DTERRA_SKIP_LUA_DOWNLOAD=ON"
-    "-DCLANG_RESOURCE_DIR=${llvmMerged}/lib/clang/${clangVersion}"
+    "-DCLANG_RESOURCE_DIR=${llvmMerged}/lib/clang/${lib.versions.major clangVersion}"
   ] ++ lib.optional enableCUDA "-DTERRA_ENABLE_CUDA=ON";
 
   doCheck = true;


### PR DESCRIPTION
The commit immediately after this, https://github.com/LuaJIT/LuaJIT/commit/a2ce8114f107464473070427e69e84f4923bd08a, backports syntax changes from LuaJIT 3.0 into the v2.1 branch. These changes introduce additional syntax that may cause incompatibilities with Terra, even if the syntax does not conflict with existing, pure LuaJIT programs per se. For now we'll stay on this commit while we consider the path forward.